### PR TITLE
fix an issue when value returned for key "platform" is null

### DIFF
--- a/processMetadata.py
+++ b/processMetadata.py
@@ -25,7 +25,10 @@ def __setGenres(komga_metadata, bangumi_metadata):
     '''
     genrelist = []
     # TODO bangumi并没有将漫画划分流派，后续可以考虑从tags中提取匹配
-    genrelist.append(bangumi_metadata["platform"])
+    if bangumi_metadata["platform"] is None:
+        genrelist.append("其他")
+    else:
+        genrelist.append(bangumi_metadata["platform"])
     for info in bangumi_metadata["infobox"]:
         if info["key"] == "连载杂志":
             if type(info["value"]) == list:


### PR DESCRIPTION
Bangumi API 返回的元数据中，`platform`键的值可能为`null`，以[这个条目](https://bgm.tv/subject/497784)为例，https://api.bgm.tv/v0/subjects/497784 的返回值为：  
```json
{
  "date": "2024-04-29",
  "platform": null,
  "images": {...}
  ...
}
```
此时会引发Komga报错：  
```
2025-02-11 20:48:49,279 - root - ERROR - komgaApi.py : 145 - An error occurred: 500 Server Error:  for url: https://books.kenxu.top:5/api/v1/series/0JS52GDJYCBT6/metadata
2025-02-11 20:48:49,291 - root - WARNING - db.py    : 54 - Failed to update series: manga, komga update failed
2025-02-11 20:48:49,292 - root - INFO - refreshMetadata.py : 143 - Finish! succeed: 0, failed: 1
```
解决方法是增加对`platform`值的判断，若值为`null`则修改为“其他”