### PR TITLE
fix: 分离了 RECHECK_FAILED_SERIES 和 CREATE_FAILED_COLLECTION 选项

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,14 +119,12 @@ This metadata then gets converted to be compatible to Komga and then gets sent t
 
 ## 创建失败收藏（可选）
 
-将`CREATE_FAILED_COLLECTION`配置为`True`，程序会在刷新完成后，将所有刷新失败的系列添加到指定收藏（默认名：`FAILED_COLLECTION`）。
-
-每次运行都会根据**本次**运行数据重新创建此收藏（无失败则跳过）。
+将`CREATE_FAILED_COLLECTION`配置为`True`，程序会在刷新完成后，将**所有**刷新失败的系列添加到指定收藏（默认名：`FAILED_COLLECTION`）。
 
 > [!TIP]
 >
 > - 在此收藏中按照[如何修正错误元数据](#如何修正错误元数据)操作即可~~治疗强迫症~~
-> - 如果要将之前所有失败的系列都添加至收藏，则需要将`RECHECK_FAILED_SERIES`配置为`True`
+> - 此收藏采用`手动排序`，因此最新失败的系列在此收藏的最后面
 
 ## 其他配置说明
 

--- a/refreshMetadata.py
+++ b/refreshMetadata.py
@@ -2,7 +2,7 @@ from api.bangumiModel import SubjectRelation
 from tools.getTitle import ParseTitle
 import processMetadata
 from time import strftime, localtime
-from tools.getNumber import getNumber,NumberType
+from tools.getNumber import getNumber, NumberType
 from tools.env import *
 from tools.log import logger
 from tools.notification import send_notification
@@ -14,13 +14,14 @@ bgm = env.bgm
 komga = env.komga
 cursor, conn = initSqlite3()
 
+
 def refresh_metadata():
     '''
     刷新书籍系列元数据
     '''
     all_series = env.all_series
-    
-    parse_title=ParseTitle()
+
+    parse_title = ParseTitle()
 
     # 批量获取所有series_id
     series_ids = [series['id'] for series in all_series]
@@ -42,16 +43,16 @@ def refresh_metadata():
 
         # Get the subject id from the Correct Bgm Link (CBL) if it exists
         subject_id = None
-        force_refresh_flag=False
+        force_refresh_flag = False
         for link in series['metadata']['links']:
             if link['label'].lower() == "cbl":
                 subject_id = link['url'].split("/")[-1]
                 logger.debug("use cbl "+subject_id+" for "+series_name)
                 # Get the metadata for the series from bangumi
                 metadata = bgm.get_subject_metadata(subject_id)
-                force_refresh_flag=True
+                force_refresh_flag = True
                 break
-        
+
         if not force_refresh_flag:
             # 找到对应的series_record
             series_record = next(
@@ -62,7 +63,8 @@ def refresh_metadata():
                 if series_record[2] == 1:
                     subject_id = cursor.execute(
                         "SELECT subject_id FROM refreshed_series WHERE series_id=?", (series_id,)).fetchone()[0]
-                    refresh_book_metadata(subject_id,series_id, force_refresh_flag)
+                    refresh_book_metadata(
+                        subject_id, series_id, force_refresh_flag)
                     continue
 
                 # recheck or skip failed series
@@ -73,7 +75,7 @@ def refresh_metadata():
         # Use the bangumi API to search for the series by title on komga
         if subject_id == None:
             logger.debug("search for "+series_name+"in bangumi")
-            title=parse_title.get_title(series_name)
+            title = parse_title.get_title(series_name)
             if title == None:
                 failed_count, failed_comic = record_series_status(
                     conn, series_id, subject_id, 0, series_name, "None", failed_count, failed_comic)
@@ -88,15 +90,15 @@ def refresh_metadata():
                     conn, series_id, subject_id, 0, series_name, "no subject in bangumi", failed_count, failed_comic)
                 failed_series_ids.append(series_id)
                 continue
-        
+
         if not metadata:
             logger.warning("Failed to get metadata: "+series_name)
             continue
-        
+
         komga_metadata = processMetadata.setKomangaSeriesMetadata(
             metadata, series_name, bgm)
 
-        if(komga_metadata.isvalid == False):
+        if (komga_metadata.isvalid == False):
             failed_count, failed_comic = record_series_status(
                 conn, series_id, subject_id, 0, series_name, komga_metadata.title+" metadata invalid", failed_count, failed_comic)
             failed_series_ids.append(series_id)
@@ -119,35 +121,49 @@ def refresh_metadata():
 
         # Update the metadata for the series on komga
         is_success = komga.update_series_metadata(series_id, series_data)
-        if(is_success):
+        if (is_success):
             success_count, success_comic = record_series_status(
                 conn, series_id, subject_id, 1, series_name, komga_metadata.title, success_count, success_comic)
             # 使用 Bangumi 图片替换原封面
             # 确保没有上传过海报，避免重复上传
             if USE_BANGUMI_THUMBNAIL and len(komga.get_series_thumbnails(series_id)) == 0:
-                thumbnail=bgm.get_subject_thumbnail(metadata)
-                replace_thumbnail_result=komga.update_series_thumbnail(series_id, thumbnail)
+                thumbnail = bgm.get_subject_thumbnail(metadata)
+                replace_thumbnail_result = komga.update_series_thumbnail(
+                    series_id, thumbnail)
                 if replace_thumbnail_result:
                     logger.debug("replace thumbnail for series: "+series_name)
                 else:
-                    logger.error("Failed to replace thumbnail for series: "+series_name)
+                    logger.error(
+                        "Failed to replace thumbnail for series: "+series_name)
         else:
             failed_count, failed_comic = record_series_status(
                 conn, series_id, subject_id, 0, series_name, "komga update failed", failed_count, failed_comic)
             failed_series_ids.append(series_id)
             continue
 
-        refresh_book_metadata(subject_id,series_id, force_refresh_flag)
+        refresh_book_metadata(subject_id, series_id, force_refresh_flag)
 
     # Add the series that failed to obtain metadata to the collection
-    if CREATE_FAILED_COLLECTION and failed_series_ids:
-        collection_name="FAILED_COLLECTION"
-        if komga.replace_collection(collection_name, False, failed_series_ids):
+    if CREATE_FAILED_COLLECTION:
+        collection_name = "FAILED_COLLECTION"
+
+        # TODO: 匹配错误的系列其update_success也是1, 需要找到一种方法将之筛选出来
+
+        # 将db中update_success为1的series_ids筛选出来
+        all_failed_series_ids = [row[0] for row in cursor.execute(
+            "SELECT series_id FROM refreshed_series WHERE update_success = 0").fetchall()]
+        # 包含本次执行所发现的新增匹配失败系列ID
+        if failed_series_ids:
+            # 把sqlite里的未更新项并入failed_series_ids
+            all_failed_series_ids = list(
+                set(failed_series_ids.append(all_failed_series_ids)))
+        # 用all_failed_series_ids 创建 FAILED_COLLECTION
+        if komga.replace_collection(collection_name, False, all_failed_series_ids):
             logger.info(
                 "Successfully replace collection: "+collection_name)
         else:
             logger.error("Failed to replace collection: "+collection_name)
-            
+
     logger.info("Finish! succeed: "+str(success_count) +
                 ", failed: "+str(failed_count))
     send_notification("已完成刷新！", "<font color='green'>已成功刷新："+str(success_count)+"</font> \n ---\n 包含以下条目：\n"+success_comic+"\n" +
@@ -155,12 +171,11 @@ def refresh_metadata():
                       strftime('%Y-%m-%d %H:%M:%S', localtime()))
 
 
-
-def update_book_metadata(book_id, related_subject, book_name,number):
+def update_book_metadata(book_id, related_subject, book_name, number):
     # Get the metadata for the book from bangumi
     book_metadata = processMetadata.setKomangaBookMetadata(
         related_subject['id'], number, book_name, bgm)
-    if(book_metadata.isvalid == False):
+    if (book_metadata.isvalid == False):
         record_book_status(
             conn, book_id, related_subject['id'], 0, book_name, "metadata invalid")
         return
@@ -180,23 +195,24 @@ def update_book_metadata(book_id, related_subject, book_name,number):
     # Update the metadata for the series on komga
     is_success = komga.update_book_metadata(
         book_id, book_data)
-    if(is_success):
+    if (is_success):
         record_book_status(
             conn, book_id, related_subject['id'], 1, book_name, "")
-        
+
         # 使用 Bangumi 图片替换原封面
         # 确保没有上传过海报，避免重复上传，排除 komga 生成的封面
         if USE_BANGUMI_THUMBNAIL_FOR_BOOK and len(komga.get_book_thumbnails(book_id)) == 1:
-            thumbnail=bgm.get_subject_thumbnail(related_subject)
-            replace_thumbnail_result=komga.update_book_thumbnail(book_id, thumbnail)
+            thumbnail = bgm.get_subject_thumbnail(related_subject)
+            replace_thumbnail_result = komga.update_book_thumbnail(
+                book_id, thumbnail)
             if replace_thumbnail_result:
                 logger.debug("replace thumbnail for book: "+book_name)
             else:
-                logger.error("Failed to replace thumbnail for book: "+book_name)
+                logger.error(
+                    "Failed to replace thumbnail for book: "+book_name)
     else:
         record_book_status(
             conn, book_id, related_subject['id'], 0, book_name, "komga update failed")
-
 
 
 def refresh_book_metadata(subject_id, series_id, force_refresh_flag):
@@ -224,13 +240,15 @@ def refresh_book_metadata(subject_id, series_id, force_refresh_flag):
     for book in books['content']:
         book_id = book['id']
         book_name = book['name']
-        
+
         # Get the subject id from the Correct Bgm Link (CBL) if it exists
         for link in book['metadata']['links']:
             if link['label'].lower() == "cbl":
-                cbl_subject=bgm.get_subject_metadata(link['url'].split("/")[-1])
-                number,_ = getNumber(cbl_subject['name'] + cbl_subject['name_cn'])
-                update_book_metadata(book_id, cbl_subject, book_name,number)
+                cbl_subject = bgm.get_subject_metadata(
+                    link['url'].split("/")[-1])
+                number, _ = getNumber(
+                    cbl_subject['name'] + cbl_subject['name_cn'])
+                update_book_metadata(book_id, cbl_subject, book_name, number)
                 break
 
         # 找到对应的book_record
@@ -254,7 +272,7 @@ def refresh_book_metadata(subject_id, series_id, force_refresh_flag):
             # Get the number for each related subject by finding the last number in the name or name_cn field
             subjects_numbers = []
             for subject in related_subjects:
-                number,_ = getNumber(subject['name'] + subject['name_cn'])
+                number, _ = getNumber(subject['name'] + subject['name_cn'])
                 try:
                     subjects_numbers.append(number)
                 except ValueError:
@@ -262,16 +280,17 @@ def refresh_book_metadata(subject_id, series_id, force_refresh_flag):
                                  subject['name'] + ", " + subject['name_cn'])
 
         # get nunmber from book name
-        book_number, number_type=getNumber(book_name)
+        book_number, number_type = getNumber(book_name)
         ep_flag = True
-        if number_type not in (NumberType.CHAPTER , NumberType.NONE):
+        if number_type not in (NumberType.CHAPTER, NumberType.NONE):
             # Update the metadata for the book if its number matches a related subject number
             for i, number in enumerate(subjects_numbers):
                 if book_number == number:
                     ep_flag = False
-                    
-                    update_book_metadata(book_id, related_subjects[i], book_name,number)
-                    
+
+                    update_book_metadata(
+                        book_id, related_subjects[i], book_name, number)
+
                     break
         # 修正`话`序号
         if ep_flag:


### PR DESCRIPTION
改进: https://github.com/chu-shen/BangumiKomga/issues/49

- 现在 `RECHECK_FAILED_SERIES` 仅关注刷新元数据
- 现在 `CREATE_FAILED_COLLECTION` 将会跟踪全部已匹配失败的元数据

已知问题:
 
- 匹配错误但无法被CBL修正的系列无法正确被 `FAILED_COLLECTION` 跟踪

