### PR TITLE
fix: 添加 IS_NOVEL_ONLY 选项指定是否komga只包含小说数据

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
   - [消息通知（可选）](#消息通知可选)
   - [创建失败收藏（可选）](#创建失败收藏可选)
   - [其他配置说明](#其他配置说明)
-  - [如何修正错误元数据](#如何修正错误元数据)
   - [为小说添加元数据](#为小说添加元数据)
+  - [如何修正错误元数据](#如何修正错误元数据)
   - [同步阅读进度](#同步阅读进度)
   - [命名建议](#命名建议)
   - [Issues \& Pull Requests](#issues--pull-requests)
@@ -174,6 +174,12 @@
     - [chu-shen/BangumiKomga#37](https://github.com/chu-shen/BangumiKomga/issues/37)
   - 如果要对此功能启用前的系列进行修改，请在`scripts`目录下手动运行一次`python sortTitleByLetter.py`
 
+## 为小说添加元数据
+
+Komga 并没有区分漫画与小说，建议不同类型使用不同库
+
+`IS_NOVEL_ONLY`：设置为`True`时，将只匹配小说数据；默认设置为`False`，匹配漫画数据
+
 ## 如何修正错误元数据
 
 人工修正错误元数据可以使用`cbl(Correct Bangumi Link)`，只需在系列元数据的链接中填入`cbl`和该漫画系列的 bangumi 地址。将强制使用此链接，不再进行刮削。与`RECHECK_FAILED_SERIES`配置无关
@@ -195,12 +201,6 @@
 - 系列元数据更新错误，即匹配错误，刮削成其他条目：
   - 填入上面提到的信息
   - 正常执行`python refreshMetadata.py`
-
-## 为小说添加元数据
-
-Komga 并没有区分漫画与小说。
-
-可以尝试修改代码，使其**只应用**于 Komga 的**小说库**：将`resortSearchResultsList.py`中的`SubjectPlatform.parse(manga_metadata["platform"]) != SubjectPlatform.Novel`修改为`SubjectPlatform.parse(manga_metadata["platform"]) == SubjectPlatform.Novel`
 
 ## 同步阅读进度
 

--- a/config/config.template.py
+++ b/config/config.template.py
@@ -25,6 +25,8 @@ RECHECK_FAILED_SERIES = False
 RECHECK_FAILED_BOOKS = False
 # 创建收藏
 CREATE_FAILED_COLLECTION = False
+# 只应用于 Komga 的小说库
+IS_NOVEL_ONLY = False
 
 # 消息通知
 # 支持： 'GOTIFY', 'WEBHOOK', 'HEALTHCHECKS'

--- a/tools/resortSearchResultsList.py
+++ b/tools/resortSearchResultsList.py
@@ -1,5 +1,6 @@
 from thefuzz import fuzz
 from api.bangumiModel import SubjectPlatform
+from config.config import IS_NOVEL_ONLY
 
 
 def compute_name_score_by_fuzzy(name, name_cn, infobox, target):
@@ -29,15 +30,19 @@ def resort_search_list(query, results, threshold, DataSource):
         manga_metadata = DataSource.get_subject_metadata(manga_id)
         if not manga_metadata:
             continue
+        # 根据 IS_NOVEL_ONLY 配置判断是否只应用于 Komga 的小说库
+        if IS_NOVEL_ONLY:
+            novel_filter = SubjectPlatform.parse(
+                manga_metadata["platform"]) == SubjectPlatform.Novel
+        else:
+            novel_filter = SubjectPlatform.parse(
+                manga_metadata["platform"]) != SubjectPlatform.Novel
         # bangumi书籍类型包括：漫画、小说、画集、其他
         # 由于komga不支持小说文字的读取，这里直接忽略`小说`类型，避免返回错误结果
         # bangumi书籍系列包括：系列、单行本
         # 此处需去除漫画系列的单行本，避免干扰，官方 API 已添加 series 字段（是否系列，仅对书籍类型的条目有效）
         # bangumi数据中存在单行本与系列未建立联系的情况
-        if (
-            SubjectPlatform.parse(manga_metadata["platform"]) != SubjectPlatform.Novel
-            and manga_metadata["series"]
-        ):
+        if novel_filter and manga_metadata["series"]:
             # 计算得分
             score = compute_name_score_by_fuzzy(
                 manga_metadata["name"],

--- a/tools/resortSearchResultsList.py
+++ b/tools/resortSearchResultsList.py
@@ -30,19 +30,16 @@ def resort_search_list(query, results, threshold, DataSource):
         manga_metadata = DataSource.get_subject_metadata(manga_id)
         if not manga_metadata:
             continue
-        # 根据 IS_NOVEL_ONLY 配置判断是否只应用于 Komga 的小说库
-        if IS_NOVEL_ONLY:
-            novel_filter = SubjectPlatform.parse(
-                manga_metadata["platform"]) == SubjectPlatform.Novel
-        else:
-            novel_filter = SubjectPlatform.parse(
-                manga_metadata["platform"]) != SubjectPlatform.Novel
-        # bangumi书籍类型包括：漫画、小说、画集、其他
-        # 由于komga不支持小说文字的读取，这里直接忽略`小说`类型，避免返回错误结果
         # bangumi书籍系列包括：系列、单行本
         # 此处需去除漫画系列的单行本，避免干扰，官方 API 已添加 series 字段（是否系列，仅对书籍类型的条目有效）
         # bangumi数据中存在单行本与系列未建立联系的情况
-        if novel_filter and manga_metadata["series"]:
+        if not manga_metadata["series"]:
+            continue
+        # bangumi书籍类型包括：漫画、小说、画集、其他
+        platform=SubjectPlatform.parse(manga_metadata["platform"])
+        # 根据 IS_NOVEL_ONLY 配置判断是否只应用于 Komga 的小说库
+        is_target_platform = (platform == SubjectPlatform.Novel) == IS_NOVEL_ONLY
+        if is_target_platform:
             # 计算得分
             score = compute_name_score_by_fuzzy(
                 manga_metadata["name"],


### PR DESCRIPTION
#### 主要改动:

- 添加 `IS_NOVEL_ONLY` 选项指定是否komga只包含小说数据
- 使 `IS_NOVEL_ONLY` 同时兼容规则 `SubjectPlatform.parse(manga_metadata["platform"]) == SubjectPlatform.Novel` 和 `SubjectPlatform.parse(manga_metadata["platform"]) != SubjectPlatform.Novel`