### PR TITLE
doc: 更新`docker compose`文件以适配新的配置文件

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@
         - /path/BangumiKomga/config.py:/app/config/config.py   # 内容更改见 step.2
         - /path/BangumiKomga/recordsRefreshed.db:/app/recordsRefreshed.db
         - /path/BangumiKomga/logs:/app/logs
-        - /path/BangumiKomga/archivedata:/app/archivedata # 离线元数据（可选）
+        - /path/BangumiKomga/archivedata:/app/archivedata # 离线元数据（可选），详见`ARCHIVE_FILES_DIR`
     ```
 
 2. 将 `config/config.template.py` 重命名为 `config/config.py`, 并修改 `KOMGA_BASE_URL`, `KOMGA_EMAIL` 和 `KOMGA_EMAIL_PASSWORD` 以便程序访问你的 Komga 实例(此用户需要有 Komga 元数据修改权限)。

--- a/README.md
+++ b/README.md
@@ -92,8 +92,7 @@
         - /path/BangumiKomga/config.py:/app/config/config.py   # 内容更改见 step.2
         - /path/BangumiKomga/recordsRefreshed.db:/app/recordsRefreshed.db
         - /path/BangumiKomga/logs:/app/logs
-        # 使用 `ARCHIVE_FILES_DIR`中定义的目录名称
-        - /path/BangumiKomga/<archivedata>:/app/<archivedata>
+        - /path/BangumiKomga/archivedata:/app/archivedata # 离线元数据（可选）
     ```
 
 2. 将 `config/config.template.py` 重命名为 `config/config.py`, 并修改 `KOMGA_BASE_URL`, `KOMGA_EMAIL` 和 `KOMGA_EMAIL_PASSWORD` 以便程序访问你的 Komga 实例(此用户需要有 Komga 元数据修改权限)。
@@ -185,7 +184,6 @@
 ## 以后台服务形式运行
 
 - `USE_BANGUMI_KOMGA_SERVICE`：设置为`True`时，以后台服务形式运行
-  - 需搭配`ARCHIVE_FILES_DIR`使用
 
 - `SERVICE_POLL_INTERVAL`：后台增量更新轮询间隔，单位秒
 

--- a/README.md
+++ b/README.md
@@ -89,9 +89,11 @@
         image: chu1shen/bangumikomga:main
         container_name: bangumikomga
         volumes:
-        - /path/BangumiKomga/config.py:/app/config/config.py   # see step.2
+        - /path/BangumiKomga/config.py:/app/config/config.py   # 内容更改见 step.2
         - /path/BangumiKomga/recordsRefreshed.db:/app/recordsRefreshed.db
         - /path/BangumiKomga/logs:/app/logs
+        # 使用 `ARCHIVE_FILES_DIR`中定义的目录名称
+        - /path/BangumiKomga/<archivedata>:/app/<archivedata>
     ```
 
 2. 将 `config/config.template.py` 重命名为 `config/config.py`, 并修改 `KOMGA_BASE_URL`, `KOMGA_EMAIL` 和 `KOMGA_EMAIL_PASSWORD` 以便程序访问你的 Komga 实例(此用户需要有 Komga 元数据修改权限)。
@@ -183,6 +185,7 @@
 ## 以后台服务形式运行
 
 - `USE_BANGUMI_KOMGA_SERVICE`：设置为`True`时，以后台服务形式运行
+  - 需搭配`ARCHIVE_FILES_DIR`使用
 
 - `SERVICE_POLL_INTERVAL`：后台增量更新轮询间隔，单位秒
 

--- a/refreshMetadata.py
+++ b/refreshMetadata.py
@@ -254,6 +254,7 @@ def _filter_new_modified_series(library_id=None):
     """
     过滤出新更改系列元数据
     """
+    os.makedirs(ARCHIVE_FILES_DIR, exist_ok=True)
     # 读取上次修改时间
     LastModifiedCacheFilePath = os.path.join(
         ARCHIVE_FILES_DIR, "komga_last_modified_time.json"


### PR DESCRIPTION
由于`komga_last_modified_time.json`和`archive_update_time.json`均位于`ARCHIVE_FILES_DIR`中, 导致`USE_BANGUMI_KOMGA_SERVICE`也依赖于`ARCHIVE_FILES_DIR`. 因此更新compose文档并提示该配置的依赖关系, 以防只启动轮询服务但不使用本地Archive的用户在log中出现大量的:
```bash
2025-05-08 23:39:09,300 - root - WARNING - cacheTime.py : 20 - 缓存文件 ./archivedata/komga_last_modified_time.json 不存在，使用默认时间
......
2025-05-08 23:39:32,634 - root - ERROR - refreshMetadataServive.py : 36 - 刷新失败: [Errno 2] No such file or directory: './archivedata/komga_last_modified_time.json'
Traceback (most recent call last):
  File "refreshMetadataServive.py", line 33, in _safe_refresh
    refresh_func()
  File "/app/refreshMetadata.py", line 315, in refresh_partial_metadata
    recent_modified_series[0]["lastModified"],
  File "/app/tools/cacheTime.py", line 30, in save_time
    with open(file_path, "w") as f:
FileNotFoundError: [Errno 2] No such file or directory: './archivedata/komga_last_modified_time.json'
```
错误