### PR TITLE
fix: 修复`get_data_by_id()`的ID类型错误

### DIFF
--- a/bangumiArchive/indexedJsonlinesRead.py
+++ b/bangumiArchive/indexedJsonlinesRead.py
@@ -65,7 +65,7 @@ class IndexedDataReader:
         try:
             targetID = int(targetID)
         except Exception as e:
-            logger.warning(f"无法将传入值视为 ID: {targetID}, {e}")
+            logger.debug(f"无法将传入值视为 ID: {targetID}, {e}")
             return {}
 
         # 检查ID是否存在

--- a/bangumiArchive/indexedJsonlinesRead.py
+++ b/bangumiArchive/indexedJsonlinesRead.py
@@ -62,6 +62,12 @@ class IndexedDataReader:
         """
         根据ID从数据文件中快速获取对应行内容
         """
+        try:
+            targetID = int(targetID)
+        except Exception as e:
+            logger.warning(f"无法将传入值视为 ID: {targetID}, {e}")
+            return {}
+
         # 检查ID是否存在
         if targetID not in self.id_offsets:
             logger.debug(f"未在索引中找到 ID: {targetID}")


### PR DESCRIPTION
修复 https://github.com/chu-shen/BangumiKomga/issues/85 中提到的大量 
> `2025-05-23 13:23:58,933 - root - WARNING - indexedJsonlinesRead.py : 67 - 未在索引中找到 ID XXXXXXX`

索引错误