### PR TITLE
feat: 添加`unittest`测试

### DIFF
--- a/.github/workflows/unitest-ci.yml
+++ b/.github/workflows/unitest-ci.yml
@@ -1,0 +1,33 @@
+name: Unittest CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set Python Version ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install requirement
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run Unittest
+        run: |
+          python run_unittests.py
+
+      - name: 上传测试结果
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: test-results/

--- a/.github/workflows/unitest-ci.yml
+++ b/.github/workflows/unitest-ci.yml
@@ -20,16 +20,16 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install requirement
+      - name: Install Requirements And Test-only Package
         run: |
-          python -m pip install --upgrade pip
           pip install -r requirements.txt
-          
+          pip install coverage
+
       - name: Run Unittest
         run: |
           python run_unittests.py
 
-      - name: 上传测试结果
+      - name: Upload Test Results
         uses: actions/upload-artifact@v4
         with:
           name: test-results

--- a/.github/workflows/unitest-ci.yml
+++ b/.github/workflows/unitest-ci.yml
@@ -14,14 +14,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Set Python Version ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Install requirement
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          
       - name: Run Unittest
         run: |
           python run_unittests.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 config.py
 recordsRefreshed.db
 refreshMetadata.log
-archive_update_time.json
-komga_last_modified_time.json
 __pycache__/
 .vscode
+*.json*
 *.jsonlines*

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 .vscode
 *.json*
 *.jsonlines*
+test_results/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# 是否需要升级python版本?
 FROM python:3.7 AS builder
 WORKDIR /app
 COPY install/requirements.txt install/requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+# pip install pipreqs
+# pipreqs --force
+
+pypinyin==0.54.0
+Requests==2.32.3
+thefuzz==0.22.1
+zhconv==1.4.3

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4,6 +4,9 @@ import unittest
 from datetime import datetime
 import xml.etree.ElementTree as ET
 
+# TODO: 覆盖率?
+
+
 # 添加源代码路径（根据实际项目结构调整）
 sys.path.insert(0, os.path.abspath('src'))
 
@@ -24,22 +27,23 @@ def run_unit_tests():
     report_dir = "test_results"
     os.makedirs(report_dir, exist_ok=True)
 
-    # 发现测试用例
     loader = unittest.TestLoader()
+    # 自动发现 test_cases 下的所有 test_ 开头的测试用例
     suite = loader.discover(
-        start_dir='test_case',
+        start_dir='test_cases',
         pattern='test_*.py'
     )
 
     # 生成带时间戳的报告文件名
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    report_file = os.path.join(report_dir, f"test_report_{timestamp}.html")
+    report_file = os.path.join(report_dir, f"test_report_{timestamp}.txt")
 
-    # 使用标准库的 TextTestRunner 执行测试并输出到文件
+    # 使用 TextTestRunner 执行测试并输出到文件
     with open(report_file, 'w', encoding='utf-8') as f:
         runner = unittest.TextTestRunner(stream=f, verbosity=2)
         result = runner.run(suite)
 
+    # 输出 JUnit XML 格式报告
     # xml_report_file = os.path.join(report_dir, f"test_report_{timestamp}.xml")
     # write_junit_xml(result, xml_report_file)
     # print(f"JUnit XML 报告已生成: {xml_report_file}")
@@ -50,7 +54,7 @@ def run_unit_tests():
     print(f"失败用例数: {len(result.failures)}")
     print(f"错误用例数: {len(result.errors)}")
 
-    # 返回失败用例数量作为退出码（CI友好）
+    # 返回失败用例数量作为退出码
     return len(result.failures) + len(result.errors)
 
 

--- a/test_cases/test_IndexedDataReader.py
+++ b/test_cases/test_IndexedDataReader.py
@@ -1,0 +1,29 @@
+import unittest
+import os
+from unittest.mock import patch, MagicMock, mock_open
+# from tools.log import logger
+from config.config import ARCHIVE_FILES_DIR
+from bangumiArchive.indexedJsonlinesRead import IndexedDataReader
+from bangumiArchive.archiveAutoupdater import update_index
+
+
+class TestIndexedDataReader(unittest.TestCase):
+    def setUp(self):
+        # update_index()
+        self.subject_reader = IndexedDataReader(
+            os.path.join(ARCHIVE_FILES_DIR, "subject.jsonlines"))
+        self.relation_reader = IndexedDataReader(
+            os.path.join(ARCHIVE_FILES_DIR, "subject-relations.jsonlines"))
+
+    def test_date_by_index_str(self):
+        result = self.subject_reader.get_data_by_id("104227", "id")
+        self.assertEqual(result["name_cn"], "我喜欢的人—高桥真短篇集")
+
+    def test_date_by_index_int(self):
+        result = self.subject_reader.get_data_by_id(104227, "id")
+        self.assertEqual(result["name_cn"], "我喜欢的人—高桥真短篇集")
+
+    def tearDown(self):
+        # 清理
+        del self.subject_reader
+        del self.relation_reader


### PR DESCRIPTION
为实现 https://github.com/chu-shen/BangumiKomga/blob/75a2d7660ef57383ab5ab281d5d1630700ad0062/README.md?plain=1#L65

提交

主要更改:
- 添加`.github/workflows/unitest-ci.yml`以利用Github Action来实现自动测试
- 添加`run_unittests.py`自动发现 `test_cases` 目录下的所有 `test_` 开头的测试用例, 提供统一的测试运行入口
- 添加了`test_cases/test_IndexedDataReader.py`作为示例用例

剩下的就是往 `test_cases` 里哐哐加用例叻