### PR TITLE
fix:  修复Komga海报因尺寸限制上传失败

### DIFF
--- a/api/bangumiApi.py
+++ b/api/bangumiApi.py
@@ -150,24 +150,24 @@ class BangumiApiDataSource(DataSource):
         url = f"{self.BASE_URL}/v0/users/-/collections/{subject_id}"
         payload = {"vol_status": progress}
         try:
-            response = self.r.patch(url, headers=self._get_headers(), json=payload)
+            response = self.r.patch(
+                url, headers=self._get_headers(), json=payload)
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             logger.error(f"出现错误: {e}")
         return response.status_code == 204
 
     @SlideWindowRateLimiter()
-    def get_subject_thumbnail(self, subject_metadata):
+    def get_subject_thumbnail(self, subject_metadata, image_size="large"):
         """
         获取漫画封面
         """
         try:
             if subject_metadata["images"]:
-                image = subject_metadata["images"]["large"]
+                image = subject_metadata["images"][image_size]
             else:
-                image = self.get_subject_metadata(subject_metadata["id"])["images"][
-                    "large"
-                ]
+                image = self.get_subject_metadata(subject_metadata["id"])[
+                    "images"][image_size]
             thumbnail = self.r.get(image).content
         except Exception as e:
             logger.error(f"出现错误: {e}")
@@ -347,7 +347,8 @@ class BangumiDataSourceFactory:
         online = BangumiApiDataSource(config.get("access_token"))
 
         if config.get("use_local_archive", False):
-            offline = BangumiArchiveDataSource(config.get("local_archive_folder"))
+            offline = BangumiArchiveDataSource(
+                config.get("local_archive_folder"))
             return FallbackDataSource(offline, online)
 
         return online

--- a/refreshMetadata.py
+++ b/refreshMetadata.py
@@ -70,7 +70,8 @@ def refresh_metadata(series_list=None):
                         "SELECT subject_id FROM refreshed_series WHERE series_id=?",
                         (series_id,),
                     ).fetchone()[0]
-                    refresh_book_metadata(subject_id, series_id, force_refresh_flag)
+                    refresh_book_metadata(
+                        subject_id, series_id, force_refresh_flag)
                     continue
 
                 # recheck or skip failed series
@@ -166,14 +167,26 @@ def refresh_metadata(series_list=None):
                 USE_BANGUMI_THUMBNAIL
                 and len(komga.get_series_thumbnails(series_id)) == 0
             ):
-                thumbnail = bgm.get_subject_thumbnail(metadata)
-                replace_thumbnail_result = komga.update_series_thumbnail(
-                    series_id, thumbnail
-                )
-                if replace_thumbnail_result:
-                    logger.debug("替换系列: %s 的海报", series_name)
+                # 用for-else尝试多尺寸海报上传
+                for thumbnail_size in ['large', 'common', 'medium']:
+                    # 获取当前尺寸的封面
+                    thumbnail = bgm.get_subject_thumbnail(
+                        metadata, image_size=thumbnail_size)
+
+                    # 尝试更新封面
+                    replace_thumbnail_result = komga.update_series_thumbnail(
+                        series_id, thumbnail)
+
+                    if replace_thumbnail_result:
+                        logger.debug(f"成功替换系列 {series_name} 的海报")
+                        # 成功则跳出海报更新循环
+                        break
+                    else:
+                        logger.debug(
+                            "以尺寸 {thumbnail_size} 替换系列: {series_name} 的海报失败，正在尝试下一个尺寸...")
+                # 所有尺寸都失败时
                 else:
-                    logger.error("替换系列: %s 的海报失败", series_name)
+                    logger.warning(f"替换系列: {series_name} 的海报失败, 无可用尺寸")
         else:
             failed_count, failed_comic = record_series_status(
                 conn,
@@ -266,7 +279,8 @@ def _filter_new_modified_series(library_id=None):
     new_series = []
     stop_paging_flag = False
     while not stop_paging_flag:
-        temp_series = komga.get_latest_series(library_id=library_id, page=page_index)
+        temp_series = komga.get_latest_series(
+            library_id=library_id, page=page_index)
 
         if not temp_series:
             break
@@ -346,7 +360,8 @@ def update_book_metadata(book_id, related_subject, book_name, number):
     # Update the metadata for the series on komga
     is_success = komga.update_book_metadata(book_id, book_data)
     if is_success:
-        record_book_status(conn, book_id, related_subject["id"], 1, book_name, "")
+        record_book_status(
+            conn, book_id, related_subject["id"], 1, book_name, "")
 
         # 使用 Bangumi 图片替换原封面
         # 确保没有上传过海报，避免重复上传，排除 komga 生成的封面
@@ -355,7 +370,8 @@ def update_book_metadata(book_id, related_subject, book_name, number):
             and len(komga.get_book_thumbnails(book_id)) == 1
         ):
             thumbnail = bgm.get_subject_thumbnail(related_subject)
-            replace_thumbnail_result = komga.update_book_thumbnail(book_id, thumbnail)
+            replace_thumbnail_result = komga.update_book_thumbnail(
+                book_id, thumbnail)
             if replace_thumbnail_result:
                 logger.debug("替换书籍: %s 的海报 ", book_name)
             else:
@@ -399,8 +415,10 @@ def refresh_book_metadata(subject_id, series_id, force_refresh_flag):
         # Get the subject id from the Correct Bgm Link (CBL) if it exists
         for link in book["metadata"]["links"]:
             if link["label"].lower() == "cbl":
-                cbl_subject = bgm.get_subject_metadata(link["url"].split("/")[-1])
-                number, _ = getNumber(cbl_subject["name"] + cbl_subject["name_cn"])
+                cbl_subject = bgm.get_subject_metadata(
+                    link["url"].split("/")[-1])
+                number, _ = getNumber(
+                    cbl_subject["name"] + cbl_subject["name_cn"])
                 update_book_metadata(book_id, cbl_subject, book_name, number)
                 break
 

--- a/refreshMetadata.py
+++ b/refreshMetadata.py
@@ -167,7 +167,7 @@ def refresh_metadata(series_list=None):
                 USE_BANGUMI_THUMBNAIL
                 and len(komga.get_series_thumbnails(series_id)) == 0
             ):
-                # 用for-else尝试多尺寸海报上传
+                # 尝试多尺寸海报上传
                 for thumbnail_size in ['large', 'common', 'medium']:
                     # 获取当前尺寸的封面
                     thumbnail = bgm.get_subject_thumbnail(
@@ -178,15 +178,18 @@ def refresh_metadata(series_list=None):
                         series_id, thumbnail)
 
                     if replace_thumbnail_result:
-                        logger.debug(f"成功替换系列 {series_name} 的海报")
+                        logger.debug("成功替换系列: %s 的海报", series_name)
                         # 成功则跳出海报更新循环
                         break
                     else:
                         logger.debug(
-                            "以尺寸 {thumbnail_size} 替换系列: {series_name} 的海报失败，正在尝试下一个尺寸...")
+                            "以尺寸 %s 替换系列: %s 的海报失败，正在尝试下一个尺寸...",
+                            thumbnail_size,
+                            series_name,
+                        )
                 # 所有尺寸都失败时
                 else:
-                    logger.warning(f"替换系列: {series_name} 的海报失败, 无可用尺寸")
+                    logger.warning("替换系列: %s 的海报失败", series_name)
         else:
             failed_count, failed_comic = record_series_status(
                 conn,


### PR DESCRIPTION
根据 https://github.com/chu-shen/BangumiKomga/issues/53 提交

主要改动:
- 为`get_subject_thumbnail()`添加了`image_size`参数
- 修改了`refresh_metadata()`中系列的海报上传逻辑, 使用for-else循环尝试多种尺寸的海报上传
- 微调了海报上传逻辑中的日志等级

已知问题:
- 没管书籍封面上传, 只修改了系列海报
- `for thumbnail_size in ['large', 'common', 'medium']`中的`['large', 'common', 'medium']`拿出来单独处理为一个有名字可配置的列表可能更好.

https://bangumi.github.io/api/:
![image](https://github.com/user-attachments/assets/7f5330b0-e2f6-4761-aaa8-ad5e33ff1498)
