### PR TITLE
fix: 移除`|| exit 0`, 保留原始错误状态码

### DIFF
--- a/.github/workflows/unitest-ci.yml
+++ b/.github/workflows/unitest-ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Run Unittest
         # 强制返回 0 避免流水线中断
         run: |
-          python run_unittests.py || exit 0  
+          python run_unittests.py  
         continue-on-error: true
 
       - name: Upload Test Results


### PR DESCRIPTION
1. 移除`|| exit 0` 以保留原始错误状态码, 确保可以正确传递错误数
2. 使用 `continue-on-error: true` 确保流水线不会中断