### PR TITLE
test: 修复测试用例 - SSE API

### DIFF
--- a/tests/test_komga_sse_api.py
+++ b/tests/test_komga_sse_api.py
@@ -1,6 +1,5 @@
 import unittest
 from unittest.mock import MagicMock, patch
-import threading
 from api.komga_sse_api import KomgaSseClient, KomgaSseApi, RefreshEventType
 
 
@@ -166,9 +165,16 @@ class TestKomgaSseApi(unittest.TestCase):
         self.api = KomgaSseApi(
             self.base_url, self.username, self.password)
 
+    # 应特别注意以:
+    # from config.config import KOMGA_BASE_URL, KOMGA_EMAIL, KOMGA_EMAIL_PASSWORD, KOMGA_LIBRARY_LIST
+    # 方式导入的变量将作为本地变量绑定到当前模块的命名空间, 不能再使用:
+    # patch('config.config.KOMGA_LIBRARY_LIST', new=[])
+    # 而应该使用:
+    # patch('api.komga_sse_api.KOMGA_LIBRARY_LIST', new=[])
+
     def test_library_filtering_with_empty_list(self):
         """测试SSE API - 空KOMGA_LIBRARY_LIST时的事件分发逻辑"""
-        with patch('config.config.KOMGA_LIBRARY_LIST', []):
+        with patch('api.komga_sse_api.KOMGA_LIBRARY_LIST', new=[]):
             api = self.api
             callback_data = []
 
@@ -181,7 +187,7 @@ class TestKomgaSseApi(unittest.TestCase):
 
     def test_library_filtering_with_matching_id(self):
         """测试SSE API - 匹配KOMGA_LIBRARY_LIST时的事件分发逻辑"""
-        with patch('config.config.KOMGA_LIBRARY_LIST', ['lib1']):
+        with patch('api.komga_sse_api.KOMGA_LIBRARY_LIST', new=['lib1']):
             api = self.api
             callback_data = []
 
@@ -194,7 +200,7 @@ class TestKomgaSseApi(unittest.TestCase):
 
     def test_library_filtering_with_non_matching_id(self):
         """测试SSE API - 不匹配KOMGA_LIBRARY_LIST时的事件分发逻辑"""
-        with patch('config.config.KOMGA_LIBRARY_LIST', ['lib2']):
+        with patch('config.config.KOMGA_LIBRARY_LIST', new=['lib2']):
             api = self.api
             callback_data = []
 

--- a/tests/test_komga_sse_api.py
+++ b/tests/test_komga_sse_api.py
@@ -64,7 +64,7 @@ class TestKomgaSseClient(unittest.TestCase):
         patch.stopall()
 
     def test_authentication_flow(self):
-        """模拟测试认证流程"""
+        """测试SSE API - 模拟认证流程"""
         # 测试API Key认证
         api_key_client = KomgaSseClient(
             self.base_url, self.username, self.password,
@@ -93,7 +93,7 @@ class TestKomgaSseClient(unittest.TestCase):
         )
 
     def test_reconnection_logic(self):
-        """测试重连逻辑（模拟异常）"""
+        """测试SSE API - 模拟异常重连逻辑"""
         # 创建客户端
         client = KomgaSseClient(
             self.base_url, self.username, self.password,
@@ -169,7 +169,7 @@ class TestKomgaSseApi(unittest.TestCase):
             self.base_url, self.username, self.password)
 
     def test_event_filtering_and_dispatching(self):
-        """测试事件过滤与分发逻辑"""
+        """测试SSE API - 事件过滤与分发逻辑"""
         test_api = self.api
         # 准备测试回调
         callback_data = []
@@ -183,20 +183,20 @@ class TestKomgaSseApi(unittest.TestCase):
         # 测试未设置KOMGA_LIBRARY_LIST的事件分发
         with patch('config.config.KOMGA_LIBRARY_LIST', []):
             for event_type in RefreshEventType:
-                test_data = json.dumps({"libraryId": "0JR3B78BEGVYG"})
+                test_data = {"libraryId": "0JR3B78BEGVYG"}
                 test_api.on_event(event_type, test_data)
             self.assertTrue(len(callback_data) > 0)
             callback_data.clear()
 
         # 测试库过滤（匹配）
         with patch('config.config.KOMGA_LIBRARY_LIST', ["lib1"]):
-            test_api.on_event("SeriesAdded", json.dumps({"libraryId": "lib1"}))
+            test_api.on_event("SeriesAdded", {"libraryId": "lib1"})
             self.assertEqual(len(callback_data), 1)
             callback_data.clear()
 
         # 测试库过滤（不匹配）
         with patch('config.config.KOMGA_LIBRARY_LIST', ["lib2"]):
-            test_api.on_event("SeriesAdded", json.dumps({"libraryId": "lib1"}))
+            test_api.on_event("SeriesAdded", {"libraryId": "lib1"})
             self.assertEqual(len(callback_data), 0)
             callback_data.clear()
 
@@ -243,7 +243,7 @@ class TestErrorHandling(unittest.TestCase):
             self.base_url, self.username, self.password)
 
     def test_invalid_json_handling(self):
-        """测试无效JSON数据处理"""
+        """测试SSE API - 无效JSON数据处理"""
 
         # 模拟无效JSON数据
         invalid_data = '{"invalid": true'
@@ -252,7 +252,7 @@ class TestErrorHandling(unittest.TestCase):
             self.assertTrue(error_mock.called)
 
     def test_network_errors(self):
-        """测试网络错误处理"""
+        """测试SSE API - 网络错误处理"""
         # 模拟网络错误
         # _process_stream 使用 response.iter_lines() 读取行数据
         # 因此要用 response_mock.iter_lines.side_effect 来模拟异常


### PR DESCRIPTION
主要更改:
- 修复测试代码 `test_event_filtering_and_dispatching` 的 `on_event()` 传入参数错误