### PR TITLE
feat: 添加 Archive 下载进度条

### DIFF
--- a/install/requirements.txt
+++ b/install/requirements.txt
@@ -2,3 +2,4 @@ pypinyin==0.53.0
 Requests==2.32.3
 thefuzz==0.22.1
 zhconv==1.4.3
+tqdm

--- a/install/requirements.txt
+++ b/install/requirements.txt
@@ -2,4 +2,4 @@ pypinyin==0.53.0
 Requests==2.32.3
 thefuzz==0.22.1
 zhconv==1.4.3
-tqdm
+tqdm==4.67.1


### PR DESCRIPTION
主要更改:
- 在 `update_archive` 中加入下载进度条

已知问题:
- 进度条输出并未重定向到日志文件