### PR TITLE
doc: 添加交互式配置生成的文档说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
   - [消息通知（可选）](#消息通知可选)
   - [创建失败收藏（可选）](#创建失败收藏可选)
   - [其他配置说明](#其他配置说明)
+  - [交互式配置生成](#交互式配置生成)
   - [服务运行方式](#服务运行方式)
-    - [SSE 事件服务搭配 Nginx](#sse-事件服务搭配-nginx)
   - [为小说添加元数据](#为小说添加元数据)
   - [如何修正错误元数据](#如何修正错误元数据)
   - [同步阅读进度](#同步阅读进度)
@@ -64,7 +64,7 @@
 - [ ] 重构元数据更新范围及覆盖逻辑
 - [ ] 增强文件名解析
 - [ ] ~~自动化测试~~ 完善测试用例
-- [ ] 无有效配置文件时, 可用命令行交互式配置生成器和网页配置生成器生成配置
+- [ ] 使用命令行交互式配置生成器或网页配置生成器生成配置
 - [ ] 支持在匹配书籍后导出 [comicinfo.xml](https://github.com/anansi-project/comicinfo), [info.json(eze)](https://github.com/Difegue/LANraragi) 和 [series.json](https://github.com/mylar3/mylar3/wiki/series.json-schema-%28version-1.0.2%29)
 
 ## 先决条件
@@ -191,41 +191,25 @@
 
 ## 交互式配置生成
 
-- 上文中的配置项亦可通过交互式配置生成器生成。
-- 若 BangumiKomga 启动后发现在 `config` 目录下不存在有效的 `config.py` 文件，将会以命令行启动交互式配置生成器，无论 BangumiKomga 是否为初次启动。
-- 用户可手动启动命令行交互式配置生成器：
-  - 以名为 BangumiKomga 的容器为例，通过 `docker exec` 命令启动: `sudo docker exec -it BangumiKomga python conifg/configuration_generator.py`。
-  - 原生部署的实例，可直接启动： `python conifg/configuration_generator.py`。
-- 命令行交互式配置生成器将读取 `config` 目录下的配置模板文件 `config.template.py`, 文件中附有 `# @@` 的配置项将允许用户进行交互式配置, 而无需手动编辑配置文件; 而其他配置项则跳过交互式配置，以默认值直接写入配置生成文件 `config.generated.py`。命令行交互式配置生成器成功生成 `config.generated.py` 文件后，将会用配置生成文件 `config.generated.py` 覆盖 `config.py`，因此请在启动交互式配置生成流程前备份已有的配置文件。
-- 命令行交互式配置生成器的配置模板文件包含多个描述行，此处以配置项 `KOMGA_BASE_URL` 为例:
+- 大部分配置项可通过交互式配置生成器生成
+- 若 BangumiKomga 启动后发现在 `config` 目录下不存在有效的 `config.py` 文件，将会以命令行启动交互式配置生成器
 
-  ```python
-  # @@name: KOMGA_BASE_URL
-  # @@prompt: KOMGA访问地址
-  # @@type: url
-  # @@required: True
-  # @@validator: validate_url
-  # @@info:
-  KOMGA_BASE_URL = "http://IP:PORT"
-  ```
+修改配置的几种方式：
 
-  - `# @@name` 表示命令行交互式配置生成器中该配置项的显示名称 `KOMGA_BASE_URL`。
-  - `# @@prompt` 表示命令行交互式配置生成器中该配置项的输入提示。
-  - `# @@type` 表示该配置项在命令行交互式配置生成器中被视为何种数据类型，其可选值为 `password`, `string`, `url`, `boolean`, `integer`, 该例中使用 `url`。
-  - `# @@validator` 表示该配置项在命令行交互式配置生成器中应调用哪个验证器来验证有效性, 其可选值为`validate_email`，`validate_url`，`validate_bangumi_token` 和 `validate_komga_access`, 该例中使用 `validate_url`。
-  - `# @@required` 表示该配置项在命令行交互式配置生成器中是否为必填项，其可选值为 `True` 和 `False`，该例中使用 `True`。
-  - `# @@info` 表示命令行交互式配置生成器中该配置项所显示的解释文本。
-  - `KOMGA_BASE_URL = "http://IP:PORT"` 表示配置项 `KOMGA_BASE_URL` 的默认值为 `http://IP:PORT`
-  
-- 用户可以直接编辑配置生成文件 `config.generated.py` 和实际配置文件 `config.py`, 各配置项具体含义及推荐值请请仔细阅读文档前文。
-- 若命令行交互式配置生成器在 `config` 目录下没有足够的文件读写权限，可能会导致配置生成失败或配置文件覆盖失败，请检查目录和 Linux 账户的读写权限，或使用 `mv` 命令手动覆盖 `config.py` 文件。
+1. 将 `config/config.template.py` 重命名为 `config/config.py`，手动修改配置项
+2. 用户可手动启动命令行交互式配置生成器：
+   - 以名为 BangumiKomga 的容器为例，通过 `docker exec` 命令启动: `sudo docker exec -it BangumiKomga python conifg/configuration_generator.py`。
+   - 原生部署的实例，可直接启动： `python conifg/configuration_generator.py`。
 
-> [!TIP]
->
-> 网页配置生成器尚未实装
->
-- 用户亦可手动启动网页配置生成器：
-  - 浏览器访问 `web` 目录下的 `index.html` 即可
+    > [!TIP]
+    >
+    > 若命令行交互式配置生成器在 `config` 目录下没有足够的文件读写权限，可能会导致配置生成失败或配置文件覆盖失败，请检查目录和 Linux 账户的读写权限，或使用 `mv` 命令手动覆盖 `config.py` 文件。
+
+3. 用户亦可手动启动网页配置生成器：
+   - 方式一：浏览器访问 `web` 目录下的 `index.html` 即可
+   - 方式二：访问[Github Pages](https://bangumikomga.chushen.xyz/)
+
+更多细节，详见[文档](docs/generate_config.md)
 
 ## 服务运行方式
 
@@ -236,51 +220,8 @@
     - `BANGUMI_KOMGA_SERVICE_POLL_INTERVAL`：后台增量更新轮询间隔，单位秒
     - `BANGUMI_KOMGA_SERVICE_POLL_REFRESH_ALL_METADATA_INTERVAL`：多少次轮询后执行一次全量刷新
 
-### SSE 事件服务搭配 Nginx
+高级配置：[SSE 事件服务搭配 Nginx](docs/Nginx.md)
 
-推荐在 LAN 环境中连接 Komga 实例。若以 SSE 事件服务方式启动`BANGUMI KOMGA`，并且出于安全考虑将 Komga 置于 Nginx 后端, 需更改 Nginx 配置来支持 SSE 长连接。
-
-在[该issue中](https://github.com/gotson/komga/issues/2012#issuecomment-3143750732)发现`HTTP 1.1`会触发浏览器的SSE连接数限制, 请务必在server块中至少使用 `HTTP 2`, `HTTP 2`要求`HTTPS`
-
-以下为`nginx.conf`的`server`(以监听443端口为例)和`location`块配置参考:
-
-```conf
-  server {
-    listen                443 ssl http2;
-    access_log            /var/log/nginx/komga.access.log;
-    error_log             /var/log/nginx/komga.error.log;
-    server_name           komga.example.com;
-    ssl_certificate       /SSL/komga.example.com.fullchain;
-    ssl_certificate_key   /SSL/komga.example.com.key;
-    ......
-  }
-  location / {
-    # KOMGA实例地址
-    proxy_pass http://komga_backend;
-    # 关闭URL自动调整功能。
-    proxy_redirect off;
-    # 将客户端请求的 Host 头传递给后端服务器，而非使用 Nginx 代理的虚拟主机配置。
-    proxy_set_header Host $http_host;
-    # 传递客户端请求的原始协议（http 或 https），帮助后端处理 SSL 终止
-    proxy_set_header X-Forwarded-Proto $scheme;
-    # 显式指定 HTTP/1.1 协议以便支持长连接
-    proxy_http_version 1.1;
-    # proxy_set_header Upgrade $http_upgrade;
-    # 关闭 Nginx 缓冲，实时转发后端数据到客户端，避免延迟。
-    proxy_buffering off;
-    # 禁用缓存，确保每次请求SSE返回最新数据
-    proxy_cache off;
-    # 禁用 Nginx 自动添加的 Connection: keep-alive 头，避免后端服务器提前关闭长连接。
-    proxy_set_header Connection '';
-    # 强制客户端或中间代理不缓存请求结果
-    proxy_set_header Cache-Control 'no-cache';
-    # 禁用分块传输编码，确保后端直接控制数据流
-    # 后端应正确设置 Content-Type: text/event-stream
-    chunked_transfer_encoding off;
-    ......
- }
-```
-  
 ## 为小说添加元数据
 
 Komga 并没有区分漫画与小说，建议不同类型使用不同库

--- a/config/config.template.py
+++ b/config/config.template.py
@@ -61,7 +61,13 @@ USE_BANGUMI_ARCHIVE = False
 # @@validator:
 # @@info: 可以指定自建目录
 ARCHIVE_FILES_DIR = "./archivedata/"
-# 离线元数据的更新间隔, 单位为小时, 0表示不检查更新
+
+# @@name: ARCHIVE_UPDATE_INTERVAL
+# @@prompt: 离线元数据的更新间隔
+# @@type: integer
+# @@required: False
+# @@validator:
+# @@info: 单位为小时的整数值, 置为 0 表示不检查离线元数据更新
 ARCHIVE_UPDATE_INTERVAL = 168
 
 # @@name: BANGUMI_KOMGA_SERVICE_TYPE
@@ -78,7 +84,7 @@ BANGUMI_KOMGA_SERVICE_TYPE = "once"
 # @@type: integer
 # @@required: False
 # @@validator:
-# @@info: 单位秒
+# @@info: 单位为秒的整数值
 BANGUMI_KOMGA_SERVICE_POLL_INTERVAL = 20
 
 # @@name: BANGUMI_KOMGA_SERVICE_POLL_REFRESH_ALL_METADATA_INTERVAL
@@ -86,7 +92,7 @@ BANGUMI_KOMGA_SERVICE_POLL_INTERVAL = 20
 # @@type: integer
 # @@required: False
 # @@validator:
-# @@info: 多少次轮询后执行一次全量刷新
+# @@info: 整数值, 指定多少次轮询后执行一次全量刷新
 BANGUMI_KOMGA_SERVICE_POLL_REFRESH_ALL_METADATA_INTERVAL = 10000
 
 # Misc

--- a/docs/Nginx.md
+++ b/docs/Nginx.md
@@ -1,0 +1,44 @@
+# SSE 事件服务搭配 Nginx
+
+推荐在 LAN 环境中连接 Komga 实例。若以 SSE 事件服务方式启动`BANGUMI KOMGA`，并且出于安全考虑将 Komga 置于 Nginx 后端, 需更改 Nginx 配置来支持 SSE 长连接。
+
+在[该issue中](https://github.com/gotson/komga/issues/2012#issuecomment-3143750732)发现`HTTP 1.1`会触发浏览器的SSE连接数限制, 请务必在server块中至少使用 `HTTP 2`, `HTTP 2`要求`HTTPS`
+
+以下为`nginx.conf`的`server`(以监听443端口为例)和`location`块配置参考:
+
+```conf
+  server {
+    listen                443 ssl http2;
+    access_log            /var/log/nginx/komga.access.log;
+    error_log             /var/log/nginx/komga.error.log;
+    server_name           komga.example.com;
+    ssl_certificate       /SSL/komga.example.com.fullchain;
+    ssl_certificate_key   /SSL/komga.example.com.key;
+    ......
+  }
+  location / {
+    # KOMGA实例地址
+    proxy_pass http://komga_backend;
+    # 关闭URL自动调整功能。
+    proxy_redirect off;
+    # 将客户端请求的 Host 头传递给后端服务器，而非使用 Nginx 代理的虚拟主机配置。
+    proxy_set_header Host $http_host;
+    # 传递客户端请求的原始协议（http 或 https），帮助后端处理 SSL 终止
+    proxy_set_header X-Forwarded-Proto $scheme;
+    # 显式指定 HTTP/1.1 协议以便支持长连接
+    proxy_http_version 1.1;
+    # proxy_set_header Upgrade $http_upgrade;
+    # 关闭 Nginx 缓冲，实时转发后端数据到客户端，避免延迟。
+    proxy_buffering off;
+    # 禁用缓存，确保每次请求SSE返回最新数据
+    proxy_cache off;
+    # 禁用 Nginx 自动添加的 Connection: keep-alive 头，避免后端服务器提前关闭长连接。
+    proxy_set_header Connection '';
+    # 强制客户端或中间代理不缓存请求结果
+    proxy_set_header Cache-Control 'no-cache';
+    # 禁用分块传输编码，确保后端直接控制数据流
+    # 后端应正确设置 Content-Type: text/event-stream
+    chunked_transfer_encoding off;
+    ......
+ }
+```

--- a/docs/generate_config.md
+++ b/docs/generate_config.md
@@ -1,0 +1,29 @@
+# 交互式配置生成
+
+`config.template.py`配置模板文件包含多个描述行，此处以配置项`KOMGA_BASE_URL`为例进行说明:
+
+  ```python
+  # @@name: KOMGA_BASE_URL
+  # @@prompt: KOMGA访问地址
+  # @@type: url
+  # @@required: True
+  # @@validator: validate_url
+  # @@info:
+  KOMGA_BASE_URL = "http://IP:PORT"
+  ```
+
+- `# @@name` 表示该配置项的显示名称 `KOMGA_BASE_URL`。
+- `# @@prompt` 表示该配置项的输入提示。
+- `# @@type` 表示该配置项被视为何种数据类型，其可选值为 `password`, `string`, `url`, `boolean`, `integer`, 该例中使用 `url`。
+- `# @@validator` 表示该配置项应调用哪个验证器来验证有效性, 其可选值为`validate_email`，`validate_url`，`validate_bangumi_token` 和 `validate_komga_access`, 该例中使用 `validate_url`。
+- `# @@required` 表示该配置项是否为必填项，其可选值为 `True` 和 `False`，该例中使用 `True`。
+- `# @@info` 表示该配置项所显示的解释文本。
+- `KOMGA_BASE_URL = "http://IP:PORT"` 表示配置项 `KOMGA_BASE_URL` 的默认值为 `http://IP:PORT`
+
+## 命令行交互式配置生成器
+
+- 命令行交互式配置生成器将读取 `config` 目录下的配置模板文件 `config.template.py`, 文件中附有 `# @@` 的配置项将允许用户进行交互式配置, 而无需手动编辑配置文件; 而其他配置项则跳过交互式配置，以默认值直接写入配置生成文件 `config.generated.py`。命令行交互式配置生成器成功生成 `config.generated.py` 文件后，将会用配置生成文件 `config.generated.py` 覆盖 `config.py`，因此请在启动交互式配置生成流程前备份已有的配置文件，避免错误覆盖。
+
+## 网页配置生成器
+
+在[命令行交互式配置生成器](./generate_config.md#命令行交互式配置生成器)的基础上提供网页配置


### PR DESCRIPTION
根据 https://github.com/chu-shen/BangumiKomga/pull/107 提交

主要更改:
- 添加交互式配置生成的文档说明

已知问题:
- 尚未适配 `KOMGA_LIBRARY_LIST` 和 `KOMGA_COLLECTION_LIST` 的Komga直读配置
- 网页配置生成器尚未完成