### PR TITLE
fix: 修复 SSE 线程静默退出

### DIFF
--- a/api/komga_sse_api.py
+++ b/api/komga_sse_api.py
@@ -20,6 +20,22 @@ from functools import lru_cache
 from tools.log import logger
 from config.config import KOMGA_BASE_URL, KOMGA_EMAIL, KOMGA_EMAIL_PASSWORD, KOMGA_LIBRARY_LIST
 
+
+# 捕获线程内未处理异常，记录堆栈以便排查静默退出
+try:
+    def _thread_exc_handler(args):
+        try:
+            thread_name = getattr(args.thread, "name", "<unknown>")
+            logger.exception(f"线程未捕获异常: {thread_name}", exc_info=(
+                args.exc_type, args.exc_value, args.exc_traceback))
+        except Exception:
+            logger.exception("线程异常处理器自身出错")
+
+    threading.excepthook = _thread_exc_handler
+except Exception:
+    # 在某些较老的 Python 版本上可能不存在 threading.excepthook
+    pass
+
 # 可配置的订阅事件类型
 RefreshEventType = ["SeriesAdded",
                     # 扫描库文件(深度)会触发全库系列的 `SeriesChanged` 事件, 需要结合CBL判断是否实际需要刷新
@@ -35,8 +51,6 @@ RefreshEventType = ["SeriesAdded",
                     # `BookImported` 我还没见过, 可能是我从来不用导入功能
                     # "BookImported"
                     ]
-# TODO: 修复已知bug
-# (等待复现方案) 观察到执行后有概率会自动退出，未输出错误信息
 
 
 class KomgaSseClient:
@@ -51,7 +65,10 @@ class KomgaSseClient:
         self.max_retries = retries
 
         # 连接状态管理
-        self.running = False
+        # 使用 Event 作为线程安全的停止信号
+        self._stop_event = threading.Event()
+        # 记录当前活动的 Response 对象（用于在 stop() 时关闭以解除阻塞）
+        self._current_response = None
         self.retry_count = 0
         self.delay = 1
 
@@ -140,42 +157,59 @@ class KomgaSseClient:
 
     def start(self):
         """启动 SSE 监听"""
-        if self.running:
+        # 如果已有线程在运行，跳过重复启动
+        if self.thread and self.thread.is_alive():
             return
-        # FIXME: 创建了一个普通线程（未设置 daemon）来执行 _connect() 方法
-        self.running = True
+        # 清除停止信号并启动线程
+        self._stop_event.clear()
         self.thread = Thread(target=self._connect)
         self.thread.start()
         self.on_open()
 
     def stop(self):
         """停止 SSE 监听"""
-        self.running = False
-        if self.thread:
-            self.thread.join()
-        # 释放 Session
-        self.session.close()
-        self.on_close()
+        # 设置停止信号，关闭当前 response 以解除可能的阻塞读取
+        self._stop_event.set()
+        try:
+            if self._current_response is not None:
+                try:
+                    self._current_response.close()
+                except Exception:
+                    pass
+        finally:
+            # 等待线程退出
+            if self.thread:
+                self.thread.join(timeout=5)
+            # 释放 Session
+            try:
+                self.session.close()
+            except Exception:
+                pass
+            self.on_close()
 
     def _connect(self):
         """建立 SSE 连接"""
         retry_count = 0
-        while self.running:
+        while not self._stop_event.is_set():
             try:
-                with self.session.get(self.url,
-                                      stream=True,
-                                      timeout=self.timeout) as response:
+                response = self.session.get(
+                    self.url,
+                    stream=True,
+                    timeout=self.timeout
+                )
+                # 保留当前 response 以便外部 stop() 可关闭
+                self._current_response = response
+                with response:
                     if response.status_code != 200:
-                        self.on_error(
+                        # 将非200视为连接错误，触发重连逻辑
+                        raise requests.exceptions.RequestException(
                             f"Komga SSE 连接失败, HTTP {response.status_code}: {response.reason}")
-                        return
 
                     self.on_open()
                     self._process_stream(response)
                     retry_count = 0  # 成功后重置重试计数
-
             except Exception as e:
-                logger.error(f"Komga SSE 连接出错: {e}")
+                logger.error(f"Komga SSE 连接出错: {e}", exc_info=True)
                 self.on_error(e)
                 retry_count += 1
                 # 应用层自动重连, 重试self.max_retries次
@@ -188,6 +222,12 @@ class KomgaSseClient:
                 logger.info(f"将在 {delay} 秒后尝试重连...")
                 time.sleep(delay)
                 self.on_retry()
+            finally:
+                # 无论如何都清理当前 response 引用，确保 stop() 后能释放资源
+                try:
+                    self._current_response = None
+                except Exception:
+                    pass
 
     def _parse_message_line(self, line, current_event, current_data):
         """事件行消息解析器"""
@@ -217,7 +257,7 @@ class KomgaSseClient:
             # iter_lines() 没有线程安全, 应配合 self.running 使用
             # https://tedboy.github.io/requests/generated/generated/requests.Response.iter_lines.html
             for line in response.iter_lines(decode_unicode=True):
-                if not self.running:
+                if self._stop_event.is_set():
                     break
                 try:
                     # 非空行
@@ -307,6 +347,17 @@ class KomgaSseApi:
         self.series_locks = {}
         # 程序退出时自动调用
         atexit.register(self._stop_client)
+        # 启动 supervisor 以监控 sse_client 线程并在异常退出时有限次重启
+        self._supervisor_stop = threading.Event()
+        self._restart_attempts = 0
+        self._restart_window_start = None
+        self._supervisor_thread = None
+        try:
+            self._supervisor_thread = Thread(
+                target=self._supervise, name="SSE_Supervisor", daemon=True)
+            self._supervisor_thread.start()
+        except Exception:
+            logger.exception("启动 supervisor 线程失败")
 
     def _start_sse_thread(self):
         """确保 SSE 线程唯一且安全启动"""
@@ -331,9 +382,45 @@ class KomgaSseApi:
             logger.error(f"启动SSE客户端失败: {e}")
             self.sse_client.stop()
 
+    def _supervise(self):
+        """监督 SSE 客户端线程，发现非预期退出时有限次重启"""
+        MAX_ATTEMPTS = 5
+        WINDOW_SECONDS = 600
+        CHECK_INTERVAL = 10
+        while not self._supervisor_stop.is_set():
+            try:
+                client_thread = getattr(self.sse_client, 'thread', None)
+                client_stopped = getattr(self.sse_client, '_stop_event', None)
+                stopped = False
+                if client_stopped is not None and client_stopped.is_set():
+                    stopped = True
+                if (client_thread is None or not client_thread.is_alive()) and not stopped:
+                    now = time.time()
+                    if self._restart_window_start is None or now - self._restart_window_start > WINDOW_SECONDS:
+                        self._restart_window_start = now
+                        self._restart_attempts = 0
+                    if self._restart_attempts < MAX_ATTEMPTS:
+                        logger.warning(
+                            "检测到 SSE 客户端线程异常退出，尝试重启（attempt %s）", self._restart_attempts + 1)
+                        try:
+                            self._restart_attempts += 1
+                            self._restart_sse_client()
+                        except Exception:
+                            logger.exception("重启 SSE 客户端时出错")
+                    else:
+                        logger.critical("SSE 客户端在窗口期内重启次数过多，停止尝试并等待人工干预")
+                        break
+                time.sleep(CHECK_INTERVAL)
+            except Exception:
+                logger.exception("监督线程异常")
+                time.sleep(CHECK_INTERVAL)
+
     def _stop_client(self):
-        # 停止 SSE 客户端
-        self.sse_client.running = False
+        # 停止 SSE 客户端（使用其 stop() 方法保证资源被正确释放）
+        try:
+            self.sse_client.stop()
+        except Exception:
+            logger.exception("停止 SSE 客户端时出错")
 
         # 等待SSE线程结束
         if self.sse_client.thread and self.sse_client.thread.is_alive():

--- a/api/komga_sse_api.py
+++ b/api/komga_sse_api.py
@@ -126,7 +126,7 @@ class KomgaSseClient:
             # 防止取不到response.status_code
             except requests.exceptions.ConnectionError as e:
                 logger.error(
-                    f"Komga SSE 连接错误, HTTP {response.status_code}: {response.reason}")
+                    f"Komga SSE 连接错误, HTTP {response.status_code}: {response.reason}, 错误: {e}", exc_info=True)
                 return
             except Exception as e:
                 logger.error(f"Komga SSE 连接错误: {e}")
@@ -313,10 +313,9 @@ class KomgaSseApi:
         if self.sse_thread and self.sse_thread.is_alive():
             logger.warning("SSE 线程已运行，跳过重复启动")
             return
-        # FIXME: 启动的是一个守护线程
+        # 启动监督线程（非守护），由主程序负责生命周期
         self.sse_thread = Thread(
             target=self._start_client,
-            daemon=True,  # 设置为守护线程
             name="SSE_Client_Thread"
         )
         self.sse_thread.start()

--- a/api/komga_sse_api.py
+++ b/api/komga_sse_api.py
@@ -426,8 +426,29 @@ class KomgaSseApi:
         if self.sse_client.thread and self.sse_client.thread.is_alive():
             self.sse_client.thread.join(timeout=5)
 
+        # 停止 supervisor
+        try:
+            if getattr(self, '_supervisor_stop', None) is not None:
+                self._supervisor_stop.set()
+            if getattr(self, '_supervisor_thread', None) and self._supervisor_thread.is_alive():
+                self._supervisor_thread.join(timeout=2)
+        except Exception:
+            logger.exception("停止 supervisor 线程时出错")
+
         # 关闭线程池
-        self.executor.shutdown(wait=True)
+        # 先尝试非阻塞关闭，再等待有限时间
+        self.executor.shutdown(wait=False)
+        # 等待最多5秒让任务完成
+        try:
+            # Python 3.9+ 支持 timeout 参数
+            if hasattr(self.executor, 'shutdown') and 'timeout' in self.executor.shutdown.__code__.co_varnames:
+                self.executor.shutdown(wait=True, timeout=5)
+            else:
+                # 降级处理：等待所有任务完成（阻塞直到完成或手动中断）
+                self.executor.shutdown(wait=True)
+        except Exception:
+            logger.warning(
+                "ThreadPoolExecutor 关闭超时，可能存在长时间运行的任务", exc_info=True)
         logger.info("SSE 客户端和线程池已关闭")
 
     def register_series_update_callback(self, callback):
@@ -463,8 +484,18 @@ class KomgaSseApi:
                     # 更新时间戳并执行刷新
                     self.series_refresh_history[series_id] = now
                     # 提交任务到线程池
-                    self.executor.submit(callback, series_info)
+                    future = self.executor.submit(callback, series_info)
+                    # 添加回调以记录任务完成或异常
+
+                    def _log_result(future):
+                        try:
+                            future.result()
+                        except Exception as e:
+                            logger.exception(
+                                "回调任务执行异常: %s", callback.__name__, exc_info=True)
+                    future.add_done_callback(_log_result)
                 except Exception as e:
+                    logger.exception("提交回调任务时出错", exc_info=True)
                     self.on_error(e)
 
     def _restart_sse_client(self):

--- a/main.py
+++ b/main.py
@@ -1,7 +1,27 @@
 from services.service_runner import run_service
+import signal
+import logging
+import threading
+
+
+def _signal_handler(signum, frame):
+    """处理系统信号(SIGINT/SIGTERM)以优雅关闭服务"""
+    logger = logging.getLogger(__name__)
+    logger.info("收到信号 %s，正在关闭服务...", signum)
+    # 由于 run_service 内部使用 threading.Event().wait() 阻塞，
+    # 我们需要唤醒主线程以允许其处理关闭逻辑
+    threading.Event().set()  # 唤醒主线程
+    # 实际的清理工作由 service_runner.py 中的 wait_for_services 处理
+
+
+def _setup_signal_handlers():
+    """注册信号处理器"""
+    signal.signal(signal.SIGINT, _signal_handler)
+    signal.signal(signal.SIGTERM, _signal_handler)
 
 
 def main():
+    _setup_signal_handlers()
     run_service()
 
 

--- a/services/service_runner.py
+++ b/services/service_runner.py
@@ -47,6 +47,7 @@ def run_poll_service(archive_thread):
 def run_sse_service(archive_thread):
     """运行SSE服务"""
     # 启动主服务线程
+    # FIXME: 目前SSE服务的守护线程在所有非守护线程退出后会被强制终止
     service_thread = threading.Thread(
         target=sse_service, daemon=True, name="SSEService"
     )
@@ -58,6 +59,7 @@ def run_sse_service(archive_thread):
 
 def run_once_service():
     """运行一次性服务"""
+    # FIXME: 目前一次性服务未实现完整功能
     pass
 
 

--- a/services/service_runner.py
+++ b/services/service_runner.py
@@ -36,7 +36,7 @@ def run_poll_service(archive_thread):
     """运行轮询服务"""
     # 启动主服务线程
     service_thread = threading.Thread(
-        target=poll_service, daemon=True, name="PollService"
+        target=poll_service, name="PollService"
     )
     service_thread.start()
 
@@ -49,7 +49,7 @@ def run_sse_service(archive_thread):
     # 启动主服务线程
     # FIXME: 目前SSE服务的守护线程在所有非守护线程退出后会被强制终止
     service_thread = threading.Thread(
-        target=sse_service, daemon=True, name="SSEService"
+        target=sse_service, name="SSEService"
     )
     service_thread.start()
 


### PR DESCRIPTION
尝试修复 `SSE` 和 `Once` 模式下的静默退出问题

由 https://github.com/chu-shen/BangumiKomga/pull/135 重新提交至 `dev` 分支, 由 https://github.com/chu-shen/BangumiKomga/pull/145 重新拆分为堆叠 Pull Requst

相关issue: https://github.com/chu-shen/BangumiKomga/issues/128 和 https://github.com/chu-shen/BangumiKomga/issues/110 和 https://github.com/chu-shen/BangumiKomga/issues/129 和 https://github.com/chu-shen/BangumiKomga/issues/140

- 修复 `komga_sse_api.py` 中 SSE 数据行处理异常时变量名错误, 避免 `NameError` 导致线程静默崩溃
- 为错误回调添加 `exc_info=True`，确保异常堆栈完整输出到日志
- 移除 SSE 线程和 service_runner 中的 `daemon=True`，确保线程在主进程退出时不会被强制终止，允许其完成清理工作
- 新增 supervisor 守护线程，持续监控 SSE 工作线程的运行状态
- 工作线程异常退出时自动重启，支持有限次重启以防止无限循环
- 添加线程异常钩子 (`threading.excepthook`) 捕获未被处理的线程异常
- 在 `main.py` 中添加 SIGINT/SIGTERM 处理器
- 收到信号后优雅关闭所有服务线程并执行清理
- 为 SSE 事件处理添加完成回调，记录任务完成或异常状态
- 便于监控和调试长时间运行的任务