### PR TITLE
refactor: 日志重构与模块拆分

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 .coverage
 test_results/
 *.generated.py
+logs/*

--- a/api/bangumi_api.py
+++ b/api/bangumi_api.py
@@ -7,7 +7,9 @@ import requests
 from requests.adapters import HTTPAdapter
 
 from api.bangumi_model import BangumiBaseType
-from tools.log import logger
+import logging
+
+logger = logging.getLogger(__name__)
 from bangumi_archive.local_archive_searcher import (
     parse_infobox,
     search_line,

--- a/api/komga_api.py
+++ b/api/komga_api.py
@@ -4,9 +4,11 @@
 # ------------------------------------------------------------------
 
 
+import logging
 import requests
-from tools.log import logger
 from requests.adapters import HTTPAdapter
+
+logger = logging.getLogger(__name__)
 
 
 class KomgaApi:
@@ -383,9 +385,31 @@ class KomgaApi:
         # return True if the status code indicates success, False otherwise
         return response.status_code == 204
 
+    def update_collection(self, id, ordered, seriesIds):
+        """
+        update existing collection by id.
+        https://komga.org/docs/openapi/patch-collection-by-id
+        """
+        try:
+            response = self.r.patch(
+                f"{self.base_url}/collections/{id}",
+                json={"ordered": ordered, "seriesIds": seriesIds},
+            )
+            response.raise_for_status()
+        except requests.exceptions.RequestException as e:
+            logger.error(f"出现错误: {e}")
+            return False
+        # return True if the status code indicates success, False otherwise
+        return response.status_code == 204
+
     def replace_collection(self, name, ordered, seriesIds):
+        """
+        替换收藏：已存在则 PATCH 更新，不存在则 POST 创建。
+        """
         id = self.get_collection_id_by_search_name(name)
-        if id is None or self.delete_collection(id):
+        if id:
+            return self.update_collection(id, ordered, seriesIds)
+        else:
             return self.add_collection(name, ordered, seriesIds)
 
     def list_libraries(self) -> list:

--- a/api/komga_api.py
+++ b/api/komga_api.py
@@ -255,6 +255,7 @@ class KomgaApi:
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             logger.error(f"出现错误: {e}")
+            return False
         # return True if the status code indicates success, False otherwise
         return response.status_code == 204
 
@@ -270,10 +271,11 @@ class KomgaApi:
             )
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
-            if response.status_code == 413:
+            if e.response is not None and e.response.status_code == 413:
                 logger.error("缩略图过大，无法上传")
             else:
                 logger.error(f"出现错误: {e}")
+            return False
         # return True if the status code indicates success, False otherwise
         return response.status_code == 200
 
@@ -291,6 +293,7 @@ class KomgaApi:
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             logger.error(f"出现错误: {e}")
+            return False
         # return True if the status code indicates success, False otherwise
         return response.status_code == 204
 
@@ -307,6 +310,7 @@ class KomgaApi:
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             logger.error(f"出现错误: {e}")
+            return False
         # return True if the status code indicates success, False otherwise
         return response.status_code == 200
 
@@ -323,6 +327,7 @@ class KomgaApi:
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             logger.error(f"出现错误: {e}")
+            return False
         # return True if the status code indicates success, False otherwise
         return response.status_code == 200
 
@@ -336,6 +341,7 @@ class KomgaApi:
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             logger.error(f"出现错误: {e}")
+            return None
         collection = response.json()["content"]
         if collection:
             return collection[0]["id"]
@@ -357,6 +363,7 @@ class KomgaApi:
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             logger.error(f"出现错误: {e}")
+            return None
         seriesIds = response.json()["seriesIds"]
         if seriesIds:
             return seriesIds
@@ -372,6 +379,7 @@ class KomgaApi:
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             logger.error(f"出现错误: {e}")
+            return False
         # return True if the status code indicates success, False otherwise
         return response.status_code == 204
 
@@ -389,6 +397,7 @@ class KomgaApi:
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             logger.error(f"出现错误: {e}")
+            return []
         results = response.json()
         if results:
             return results
@@ -405,6 +414,7 @@ class KomgaApi:
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             logger.error(f"出现错误: {e}")
+            return []
         results = response.json()["content"]
         if results:
             return results

--- a/api/komga_sse_api.py
+++ b/api/komga_sse_api.py
@@ -20,6 +20,22 @@ from functools import lru_cache
 from tools.log import logger
 from config.config import KOMGA_BASE_URL, KOMGA_EMAIL, KOMGA_EMAIL_PASSWORD, KOMGA_LIBRARY_LIST
 
+
+# 捕获线程内未处理异常，记录堆栈以便排查静默退出
+try:
+    def _thread_exc_handler(args):
+        try:
+            thread_name = getattr(args.thread, "name", "<unknown>")
+            logger.exception(f"线程未捕获异常: {thread_name}", exc_info=(
+                args.exc_type, args.exc_value, args.exc_traceback))
+        except Exception:
+            logger.exception("线程异常处理器自身出错")
+
+    threading.excepthook = _thread_exc_handler
+except Exception:
+    # 在某些较老的 Python 版本上可能不存在 threading.excepthook
+    pass
+
 # 可配置的订阅事件类型
 RefreshEventType = ["SeriesAdded",
                     # 扫描库文件(深度)会触发全库系列的 `SeriesChanged` 事件, 需要结合CBL判断是否实际需要刷新
@@ -35,8 +51,6 @@ RefreshEventType = ["SeriesAdded",
                     # `BookImported` 我还没见过, 可能是我从来不用导入功能
                     # "BookImported"
                     ]
-# TODO: 修复已知bug
-# (等待复现方案) 观察到执行后有概率会自动退出，未输出错误信息
 
 
 class KomgaSseClient:
@@ -51,7 +65,10 @@ class KomgaSseClient:
         self.max_retries = retries
 
         # 连接状态管理
-        self.running = False
+        # 使用 Event 作为线程安全的停止信号
+        self._stop_event = threading.Event()
+        # 记录当前活动的 Response 对象（用于在 stop() 时关闭以解除阻塞）
+        self._current_response = None
         self.retry_count = 0
         self.delay = 1
 
@@ -140,42 +157,59 @@ class KomgaSseClient:
 
     def start(self):
         """启动 SSE 监听"""
-        if self.running:
+        # 如果已有线程在运行，跳过重复启动
+        if self.thread and self.thread.is_alive():
             return
-        # FIXME: 创建了一个普通线程（未设置 daemon）来执行 _connect() 方法
-        self.running = True
+        # 清除停止信号并启动线程
+        self._stop_event.clear()
         self.thread = Thread(target=self._connect)
         self.thread.start()
         self.on_open()
 
     def stop(self):
         """停止 SSE 监听"""
-        self.running = False
-        if self.thread:
-            self.thread.join()
-        # 释放 Session
-        self.session.close()
-        self.on_close()
+        # 设置停止信号，关闭当前 response 以解除可能的阻塞读取
+        self._stop_event.set()
+        try:
+            if self._current_response is not None:
+                try:
+                    self._current_response.close()
+                except Exception:
+                    pass
+        finally:
+            # 等待线程退出
+            if self.thread:
+                self.thread.join(timeout=5)
+            # 释放 Session
+            try:
+                self.session.close()
+            except Exception:
+                pass
+            self.on_close()
 
     def _connect(self):
         """建立 SSE 连接"""
         retry_count = 0
-        while self.running:
+        while not self._stop_event.is_set():
             try:
-                with self.session.get(self.url,
-                                      stream=True,
-                                      timeout=self.timeout) as response:
+                response = self.session.get(
+                    self.url,
+                    stream=True,
+                    timeout=self.timeout
+                )
+                # 保留当前 response 以便外部 stop() 可关闭
+                self._current_response = response
+                with response:
                     if response.status_code != 200:
-                        self.on_error(
+                        # 将非200视为连接错误，触发重连逻辑
+                        raise requests.exceptions.RequestException(
                             f"Komga SSE 连接失败, HTTP {response.status_code}: {response.reason}")
-                        return
 
                     self.on_open()
                     self._process_stream(response)
                     retry_count = 0  # 成功后重置重试计数
-
             except Exception as e:
-                logger.error(f"Komga SSE 连接出错: {e}")
+                logger.error(f"Komga SSE 连接出错: {e}", exc_info=True)
                 self.on_error(e)
                 retry_count += 1
                 # 应用层自动重连, 重试self.max_retries次
@@ -188,6 +222,12 @@ class KomgaSseClient:
                 logger.info(f"将在 {delay} 秒后尝试重连...")
                 time.sleep(delay)
                 self.on_retry()
+            finally:
+                # 无论如何都清理当前 response 引用，确保 stop() 后能释放资源
+                try:
+                    self._current_response = None
+                except Exception:
+                    pass
 
     def _parse_message_line(self, line, current_event, current_data):
         """事件行消息解析器"""
@@ -217,7 +257,7 @@ class KomgaSseClient:
             # iter_lines() 没有线程安全, 应配合 self.running 使用
             # https://tedboy.github.io/requests/generated/generated/requests.Response.iter_lines.html
             for line in response.iter_lines(decode_unicode=True):
-                if not self.running:
+                if self._stop_event.is_set():
                     break
                 try:
                     # 非空行
@@ -307,6 +347,17 @@ class KomgaSseApi:
         self.series_locks = {}
         # 程序退出时自动调用
         atexit.register(self._stop_client)
+        # 启动 supervisor 以监控 sse_client 线程并在异常退出时有限次重启
+        self._supervisor_stop = threading.Event()
+        self._restart_attempts = 0
+        self._restart_window_start = None
+        self._supervisor_thread = None
+        try:
+            self._supervisor_thread = Thread(
+                target=self._supervise, name="SSE_Supervisor", daemon=True)
+            self._supervisor_thread.start()
+        except Exception:
+            logger.exception("启动 supervisor 线程失败")
 
     def _start_sse_thread(self):
         """确保 SSE 线程唯一且安全启动"""
@@ -331,9 +382,45 @@ class KomgaSseApi:
             logger.error(f"启动SSE客户端失败: {e}")
             self.sse_client.stop()
 
+    def _supervise(self):
+        """监督 SSE 客户端线程，发现非预期退出时有限次重启"""
+        MAX_ATTEMPTS = 5
+        WINDOW_SECONDS = 600
+        CHECK_INTERVAL = 10
+        while not self._supervisor_stop.is_set():
+            try:
+                client_thread = getattr(self.sse_client, 'thread', None)
+                client_stopped = getattr(self.sse_client, '_stop_event', None)
+                stopped = False
+                if client_stopped is not None and client_stopped.is_set():
+                    stopped = True
+                if (client_thread is None or not client_thread.is_alive()) and not stopped:
+                    now = time.time()
+                    if self._restart_window_start is None or now - self._restart_window_start > WINDOW_SECONDS:
+                        self._restart_window_start = now
+                        self._restart_attempts = 0
+                    if self._restart_attempts < MAX_ATTEMPTS:
+                        logger.warning(
+                            "检测到 SSE 客户端线程异常退出，尝试重启（attempt %s）", self._restart_attempts + 1)
+                        try:
+                            self._restart_attempts += 1
+                            self._restart_sse_client()
+                        except Exception:
+                            logger.exception("重启 SSE 客户端时出错")
+                    else:
+                        logger.critical("SSE 客户端在窗口期内重启次数过多，停止尝试并等待人工干预")
+                        break
+                time.sleep(CHECK_INTERVAL)
+            except Exception:
+                logger.exception("监督线程异常")
+                time.sleep(CHECK_INTERVAL)
+
     def _stop_client(self):
-        # 停止 SSE 客户端
-        self.sse_client.running = False
+        # 停止 SSE 客户端（使用其 stop() 方法保证资源被正确释放）
+        try:
+            self.sse_client.stop()
+        except Exception:
+            logger.exception("停止 SSE 客户端时出错")
 
         # 等待SSE线程结束
         if self.sse_client.thread and self.sse_client.thread.is_alive():

--- a/api/komga_sse_api.py
+++ b/api/komga_sse_api.py
@@ -143,7 +143,7 @@ class KomgaSseClient:
             # 防止取不到response.status_code
             except requests.exceptions.ConnectionError as e:
                 logger.error(
-                    f"Komga SSE 连接错误, HTTP {response.status_code}: {response.reason}, 错误: {e}", exc_info=True)
+                    "Komga SSE 连接错误: %s", e, exc_info=True)
                 return
             except Exception as e:
                 logger.error(f"Komga SSE 连接错误: {e}")
@@ -160,9 +160,9 @@ class KomgaSseClient:
         # 如果已有线程在运行，跳过重复启动
         if self.thread and self.thread.is_alive():
             return
-        # 清除停止信号并启动线程
+        # 清除停止信号并启动线程 (daemon: 进程退出时自动终止，由上层 SseManager 管理生命周期)
         self._stop_event.clear()
-        self.thread = Thread(target=self._connect)
+        self.thread = Thread(target=self._connect, daemon=True)
         self.thread.start()
         self.on_open()
 
@@ -177,8 +177,8 @@ class KomgaSseClient:
                 except Exception:
                     pass
         finally:
-            # 等待线程退出
-            if self.thread:
+            # 等待线程退出（防止 self-join: 如果是当前线程则跳过 join）
+            if self.thread and self.thread is not threading.current_thread():
                 self.thread.join(timeout=5)
             # 释放 Session
             try:
@@ -212,15 +212,12 @@ class KomgaSseClient:
                 logger.error(f"Komga SSE 连接出错: {e}", exc_info=True)
                 self.on_error(e)
                 retry_count += 1
-                # 应用层自动重连, 重试self.max_retries次
-                if retry_count > self.max_retries:
-                    logger.error("超过最大重试次数，停止连接")
-                    self.stop()
+                # 无限重连，指数退避，上限 60 秒
+                delay = min(self.delay * (2 ** retry_count), 60)
+                logger.info(f"将在 {delay} 秒后尝试重连... (第 {retry_count} 次)")
+                # 用可中断的 wait 代替 time.sleep，响应 stop 信号
+                if self._stop_event.wait(delay):
                     return
-                # 指数退避
-                delay = min(self.delay * (2 ** retry_count), 30)
-                logger.info(f"将在 {delay} 秒后尝试重连...")
-                time.sleep(delay)
                 self.on_retry()
             finally:
                 # 无论如何都清理当前 response 引用，确保 stop() 后能释放资源
@@ -347,10 +344,8 @@ class KomgaSseApi:
         self.series_locks = {}
         # 程序退出时自动调用
         atexit.register(self._stop_client)
-        # 启动 supervisor 以监控 sse_client 线程并在异常退出时有限次重启
+        # 启动 supervisor 以监控 sse_client 线程并在异常退出时重启
         self._supervisor_stop = threading.Event()
-        self._restart_attempts = 0
-        self._restart_window_start = None
         self._supervisor_thread = None
         try:
             self._supervisor_thread = Thread(
@@ -367,7 +362,8 @@ class KomgaSseApi:
         # 启动监督线程（非守护），由主程序负责生命周期
         self.sse_thread = Thread(
             target=self._start_client,
-            name="SSE_Client_Thread"
+            name="SSE_Client_Thread",
+            daemon=True
         )
         self.sse_thread.start()
 
@@ -383,37 +379,33 @@ class KomgaSseApi:
             self.sse_client.stop()
 
     def _supervise(self):
-        """监督 SSE 客户端线程，发现非预期退出时有限次重启"""
-        MAX_ATTEMPTS = 5
-        WINDOW_SECONDS = 600
+        """监督 SSE 客户端线程，发现非预期退出时无限重启（指数退避，上限 60 秒）"""
         CHECK_INTERVAL = 10
+        consecutive_failures = 0
         while not self._supervisor_stop.is_set():
             try:
                 client_thread = getattr(self.sse_client, 'thread', None)
                 client_stopped = getattr(self.sse_client, '_stop_event', None)
-                stopped = False
-                if client_stopped is not None and client_stopped.is_set():
-                    stopped = True
+                stopped = client_stopped is not None and client_stopped.is_set()
                 if (client_thread is None or not client_thread.is_alive()) and not stopped:
-                    now = time.time()
-                    if self._restart_window_start is None or now - self._restart_window_start > WINDOW_SECONDS:
-                        self._restart_window_start = now
-                        self._restart_attempts = 0
-                    if self._restart_attempts < MAX_ATTEMPTS:
-                        logger.warning(
-                            "检测到 SSE 客户端线程异常退出，尝试重启（attempt %s）", self._restart_attempts + 1)
-                        try:
-                            self._restart_attempts += 1
-                            self._restart_sse_client()
-                        except Exception:
-                            logger.exception("重启 SSE 客户端时出错")
-                    else:
-                        logger.critical("SSE 客户端在窗口期内重启次数过多，停止尝试并等待人工干预")
+                    consecutive_failures += 1
+                    backoff = min(2 ** consecutive_failures, 60)
+                    logger.warning(
+                        "检测到 SSE 客户端线程异常退出，%d 秒后重启 (第 %d 次)",
+                        backoff, consecutive_failures)
+                    # 等待退避时间，但可被停止信号中断
+                    if self._supervisor_stop.wait(backoff):
                         break
-                time.sleep(CHECK_INTERVAL)
+                    try:
+                        self._restart_sse_client()
+                    except Exception:
+                        logger.exception("重启 SSE 客户端时出错")
+                else:
+                    consecutive_failures = 0  # 线程存活，重置计数
+                self._supervisor_stop.wait(CHECK_INTERVAL)
             except Exception:
                 logger.exception("监督线程异常")
-                time.sleep(CHECK_INTERVAL)
+                self._supervisor_stop.wait(CHECK_INTERVAL)
 
     def _stop_client(self):
         # 停止 SSE 客户端（使用其 stop() 方法保证资源被正确释放）
@@ -499,7 +491,12 @@ class KomgaSseApi:
                     self.on_error(e)
 
     def _restart_sse_client(self):
-        """安全重启SSE客户端"""
+        """安全重启SSE客户端（只能从非SSE线程调用）"""
+        # 防止从 SSE 连接线程内部调用导致 self-join
+        sse_thread = getattr(self.sse_client, 'thread', None)
+        if sse_thread is not None and threading.current_thread() is sse_thread:
+            logger.warning("拒绝从 SSE 线程内部重启; _connect() 的自愈循环会处理")
+            return
         try:
             self.sse_client.stop()
             time.sleep(2)  # 等待2秒后重启
@@ -518,11 +515,8 @@ class KomgaSseApi:
 
     def on_error(self, e: Exception):
         """错误事件回调函数"""
-        # 错误处理行为
+        # 错误处理行为（仅记录日志；重连由 _connect() 的无限重试循环 和 _supervise() 负责）
         logger.error(f"遇到 SSE 错误: {e} ", exc_info=True)
-        # 错误自动重连
-        if "connection" in str(e).lower():
-            self._restart_sse_client()
 
     def on_event(self, event_type, event_data):
         """订阅事件回调函数"""

--- a/api/komga_sse_api.py
+++ b/api/komga_sse_api.py
@@ -126,7 +126,7 @@ class KomgaSseClient:
             # 防止取不到response.status_code
             except requests.exceptions.ConnectionError as e:
                 logger.error(
-                    f"Komga SSE 连接错误, HTTP {response.status_code}: {response.reason}")
+                    f"Komga SSE 连接错误, HTTP {response.status_code}: {response.reason}, 错误: {e}", exc_info=True)
                 return
             except Exception as e:
                 logger.error(f"Komga SSE 连接错误: {e}")
@@ -313,10 +313,9 @@ class KomgaSseApi:
         if self.sse_thread and self.sse_thread.is_alive():
             logger.warning("SSE 线程已运行，跳过重复启动")
             return
-        # FIXME: 启动的是一个守护线程
+        # 启动监督线程（非守护），由主程序负责生命周期
         self.sse_thread = Thread(
             target=self._start_client,
-            daemon=True,  # 设置为守护线程
             name="SSE_Client_Thread"
         )
         self.sse_thread.start()

--- a/api/komga_sse_api.py
+++ b/api/komga_sse_api.py
@@ -426,8 +426,29 @@ class KomgaSseApi:
         if self.sse_client.thread and self.sse_client.thread.is_alive():
             self.sse_client.thread.join(timeout=5)
 
+        # 停止 supervisor
+        try:
+            if getattr(self, '_supervisor_stop', None) is not None:
+                self._supervisor_stop.set()
+            if getattr(self, '_supervisor_thread', None) and self._supervisor_thread.is_alive():
+                self._supervisor_thread.join(timeout=2)
+        except Exception:
+            logger.exception("停止 supervisor 线程时出错")
+
         # 关闭线程池
-        self.executor.shutdown(wait=True)
+        # 先尝试非阻塞关闭，再等待有限时间
+        self.executor.shutdown(wait=False)
+        # 等待最多5秒让任务完成
+        try:
+            # Python 3.9+ 支持 timeout 参数
+            if hasattr(self.executor, 'shutdown') and 'timeout' in self.executor.shutdown.__code__.co_varnames:
+                self.executor.shutdown(wait=True, timeout=5)
+            else:
+                # 降级处理：等待所有任务完成（阻塞直到完成或手动中断）
+                self.executor.shutdown(wait=True)
+        except Exception:
+            logger.warning(
+                "ThreadPoolExecutor 关闭超时，可能存在长时间运行的任务", exc_info=True)
         logger.info("SSE 客户端和线程池已关闭")
 
     def register_series_update_callback(self, callback):
@@ -463,8 +484,18 @@ class KomgaSseApi:
                     # 更新时间戳并执行刷新
                     self.series_refresh_history[series_id] = now
                     # 提交任务到线程池
-                    self.executor.submit(callback, series_info)
+                    future = self.executor.submit(callback, series_info)
+                    # 添加回调以记录任务完成或异常
+
+                    def _log_result(future):
+                        try:
+                            future.result()
+                        except Exception as e:
+                            logger.exception(
+                                "回调任务执行异常: %s", callback.__name__, exc_info=True)
+                    future.add_done_callback(_log_result)
                 except Exception as e:
+                    logger.exception("提交回调任务时出错", exc_info=True)
                     self.on_error(e)
 
     def _restart_sse_client(self):

--- a/api/komga_sse_api.py
+++ b/api/komga_sse_api.py
@@ -17,7 +17,9 @@ from requests.adapters import HTTPAdapter
 from threading import Thread, Lock
 from concurrent.futures import ThreadPoolExecutor
 from functools import lru_cache
-from tools.log import logger
+import logging
+
+logger = logging.getLogger(__name__)
 from config.config import KOMGA_BASE_URL, KOMGA_EMAIL, KOMGA_EMAIL_PASSWORD, KOMGA_LIBRARY_LIST
 
 

--- a/bangumi_archive/archive_autoupdater.py
+++ b/bangumi_archive/archive_autoupdater.py
@@ -1,9 +1,11 @@
+import logging
 import os
 import zipfile
 import requests
 import json
 from config.config import ARCHIVE_FILES_DIR
-from tools.log import logger
+
+logger = logging.getLogger(__name__)
 from bangumi_archive.local_archive_indexed_reader import IndexedDataReader
 from tools.cache_time import TimeCacheManager
 

--- a/bangumi_archive/local_archive_indexed_reader.py
+++ b/bangumi_archive/local_archive_indexed_reader.py
@@ -3,12 +3,13 @@ import os
 import pickle
 import re
 import mmap
+import logging
 import threading
 from threading import Lock
 from datetime import datetime, timezone
-from threading import Lock
 from typing import Dict, List, Union
-from tools.log import logger
+
+logger = logging.getLogger(__name__)
 
 
 class IndexedDataReader:
@@ -256,10 +257,13 @@ class IndexedDataReader:
             "index": index,  # 纯索引
             "index_timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")  # 索引构建时间戳
         }
-        # 保存索引
+        # 原子保存索引：先写临时文件，再 os.replace() 原子替换
+        # 防止进程在 pickle.dump 中途被杀导致索引文件半写入损坏
+        tmp_path = self.index_path + ".tmp"
         try:
-            with open(self.index_path, 'wb') as f:
+            with open(tmp_path, 'wb') as f:
                 pickle.dump(package, f, protocol=pickle.HIGHEST_PROTOCOL)
+            os.replace(tmp_path, self.index_path)  # 原子替换 (Windows/Linux 均保证)
             logger.info(
                 f"索引构建完成，共 {line_number} 行，已保存至: {self.index_path}，大小: {os.path.getsize(self.index_path) / 1024 / 1024:.1f} MB")
         except Exception as e:

--- a/bangumi_archive/local_archive_searcher.py
+++ b/bangumi_archive/local_archive_searcher.py
@@ -1,6 +1,8 @@
+import logging
 import re
 import json
-from tools.log import logger
+
+logger = logging.getLogger(__name__)
 from bangumi_archive.local_archive_indexed_reader import IndexedDataReader
 
 

--- a/bangumi_archive/periodic_archive_checker.py
+++ b/bangumi_archive/periodic_archive_checker.py
@@ -1,12 +1,13 @@
+import logging
 import threading
-import time
-from tools.log import logger
+
+logger = logging.getLogger(__name__)
 from config.config import USE_BANGUMI_ARCHIVE, ARCHIVE_UPDATE_INTERVAL
 from bangumi_archive.archive_autoupdater import check_archive
 
 
-def periodical_archive_check_service():
-    """守护线程执行定时检查"""
+def periodical_archive_check_service(stop_event=None):
+    """守护线程执行定时检查。接受 stop_event 以支持可中断等待。"""
     if not USE_BANGUMI_ARCHIVE:
         logger.debug("Bangumi Archive 未启用，跳过 Archive 检查服务")
         return None
@@ -15,10 +16,13 @@ def periodical_archive_check_service():
         logger.debug("ARCHIVE_UPDATE_INTERVAL 为 0，跳过定时检查线程创建")
         return None
 
+    if stop_event is None:
+        stop_event = threading.Event()
+
     def periodic_check():
         interval_seconds = parse_interval(hours=ARCHIVE_UPDATE_INTERVAL)
 
-        while True:
+        while not stop_event.is_set():
             try:
                 check_archive()
                 logger.info(
@@ -27,7 +31,9 @@ def periodical_archive_check_service():
             except Exception as e:
                 logger.error(f"定时检查异常: {e}")
 
-            time.sleep(interval_seconds)
+            # 用可中断的 wait 代替 time.sleep，响应停止信号
+            if stop_event.wait(interval_seconds):
+                break
 
     thread = threading.Thread(
         target=periodic_check, daemon=True, name="ArchiveUpdateChecker"

--- a/core/refresh_metadata.py
+++ b/core/refresh_metadata.py
@@ -365,7 +365,7 @@ def refresh_partial_metadata():
     if KOMGA_LIBRARY_LIST:
         for libray_item in KOMGA_LIBRARY_LIST:
             series_list = _filter_new_modified_series(
-                libray_item["LIBRARY"])["content"]
+                libray_item["LIBRARY"])
             for series in series_list:
                 series["is_novel"] = libray_item["IS_NOVEL_ONLY"]
             recent_modified_series.extend(series_list)

--- a/core/refresh_metadata.py
+++ b/core/refresh_metadata.py
@@ -5,7 +5,9 @@ import core.process_metadata as process_metadata
 from time import strftime, localtime
 from tools.get_number import get_number, NumberType
 from tools.env import *
-from tools.log import logger
+import logging
+
+logger = logging.getLogger(__name__)
 from tools.notification import send_notification
 from tools.db import init_sqlite3, record_series_status, record_book_status
 from tools.cache_time import TimeCacheManager

--- a/main.py
+++ b/main.py
@@ -1,7 +1,27 @@
 from services.service_runner import run_service
+import signal
+import logging
+import threading
+
+
+def _signal_handler(signum, frame):
+    """处理系统信号(SIGINT/SIGTERM)以优雅关闭服务"""
+    logger = logging.getLogger(__name__)
+    logger.info("收到信号 %s，正在关闭服务...", signum)
+    # 由于 run_service 内部使用 threading.Event().wait() 阻塞，
+    # 我们需要唤醒主线程以允许其处理关闭逻辑
+    threading.Event().set()  # 唤醒主线程
+    # 实际的清理工作由 service_runner.py 中的 wait_for_services 处理
+
+
+def _setup_signal_handlers():
+    """注册信号处理器"""
+    signal.signal(signal.SIGINT, _signal_handler)
+    signal.signal(signal.SIGTERM, _signal_handler)
 
 
 def main():
+    _setup_signal_handlers()
     run_service()
 
 

--- a/scripts/sort_title_by_letter.py
+++ b/scripts/sort_title_by_letter.py
@@ -2,7 +2,9 @@ import sys, os
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../")))
 from tools.env import *
-from tools.log import logger
+import logging
+
+logger = logging.getLogger(__name__)
 from pypinyin import slug, Style
 
 env = InitEnv()

--- a/scripts/update_read_progress.py
+++ b/scripts/update_read_progress.py
@@ -1,6 +1,8 @@
 from config.config import *
 from tools.env import *
-from tools.log import logger
+import logging
+
+logger = logging.getLogger(__name__)
 from warnings import deprecated
 
 

--- a/services/polling_service.py
+++ b/services/polling_service.py
@@ -1,7 +1,5 @@
 import threading
 import time
-import os
-import sqlite3
 from tools.log import logger
 from config.config import (
     BANGUMI_KOMGA_SERVICE_POLL_INTERVAL,
@@ -10,81 +8,74 @@ from config.config import (
 from core.refresh_metadata import refresh_metadata, refresh_partial_metadata
 
 
-class PollingCaller:
-    def __init__(self):
-        self.is_refreshing = False
-        self.interval = BANGUMI_KOMGA_SERVICE_POLL_INTERVAL
-        # 多少次轮询后执行一次全量刷新
-        self.refresh_all_metadata_interval = (
-            BANGUMI_KOMGA_SERVICE_POLL_REFRESH_ALL_METADATA_INTERVAL
+class PollManager:
+    """轮询管理器 — 单层 daemon 线程，用 stop_event 控制生命周期"""
+
+    def __init__(self, stop_event, poll_interval=None, full_refresh_interval=None):
+        self._stop_event = stop_event
+        self._poll_interval = poll_interval or BANGUMI_KOMGA_SERVICE_POLL_INTERVAL
+        self._full_refresh_interval = (
+            full_refresh_interval
+            or BANGUMI_KOMGA_SERVICE_POLL_REFRESH_ALL_METADATA_INTERVAL
         )
-        self.refresh_counter = 0
-        # 添加锁对象
-        self.lock = threading.Lock()
+        self._thread = None
+        self._refresh_lock = threading.Lock()
+        self._refresh_counter = 0
+
+    def start(self):
+        """启动轮询线程"""
+        if self._thread and self._thread.is_alive():
+            logger.warning("PollManager 已在运行")
+            return
+        self._thread = threading.Thread(
+            target=self._run, daemon=True, name="PollManager"
+        )
+        self._thread.start()
+        logger.info("PollManager 已启动 (间隔=%ds, 全量刷新间隔=%d次)",
+                     self._poll_interval, self._full_refresh_interval)
+
+    def stop(self):
+        """停止轮询"""
+        self._stop_event.set()
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=30)
+        logger.info("PollManager 已停止")
+
+    def _run(self):
+        """轮询主循环"""
+        while not self._stop_event.is_set():
+            try:
+                if self._refresh_counter >= self._full_refresh_interval:
+                    self._safe_refresh(refresh_metadata)
+                    self._refresh_counter = 0
+                else:
+                    self._safe_refresh(refresh_partial_metadata)
+                self._refresh_counter += 1
+            except Exception:
+                logger.exception("轮询循环异常")
+
+            # 用可中断的 wait 代替 time.sleep
+            self._stop_event.wait(self._poll_interval)
 
     def _safe_refresh(self, refresh_func):
-        """
-        封装安全刷新操作
-        """
-        with self.lock:
-            if self.is_refreshing:
-                logger.warning("已有元数据刷新任务在运行")
-                return False
-            self.is_refreshing = True
-
+        """加锁保护，防止并发刷新"""
+        if not self._refresh_lock.acquire(blocking=False):
+            logger.warning("上一轮刷新尚未完成，跳过本次")
+            return
         try:
             refresh_func()
-            return True
-        except Exception as e:
-            logger.error(f"刷新失败: {str(e)}", exc_info=True)
-            return False
+        except Exception:
+            logger.exception("刷新失败")
         finally:
-            with self.lock:
-                self.is_refreshing = False
-
-    def start_polling(self):
-        """
-        启动服务
-        """
-
-        def poll():
-            # 执行定时轮询
-            while True:
-                try:
-                    # 定时全量刷新
-                    if self.refresh_counter >= self.refresh_all_metadata_interval:
-                        success = self._safe_refresh(refresh_metadata)
-                        self.refresh_counter = 0
-                    else:
-                        success = self._safe_refresh(refresh_partial_metadata)
-                    # 更新计数器和间隔
-                    if not success:
-                        retry_delay = min(2**self.interval, 60)
-                        time.sleep(retry_delay)
-
-                    self.refresh_counter += 1
-                    # 等待一个预设时间间隔
-                    time.sleep(self.interval)
-
-                except Exception as e:
-                    logger.error(f"轮询失败: {str(e)}", exc_info=True)
-                    # 指数退避重试
-                    retry_delay = min(2**self.interval, 60)
-                    # 固定值重试
-                    # retry_delay = self.interval
-                    logger.warning(f"{retry_delay}秒后重试...")
-                    time.sleep(retry_delay)
-                    continue
-
-        # 使用守护线程启动轮询
-        threading.Thread(target=poll, daemon=True).start()
-
+            self._refresh_lock.release()
 
 def poll_service():
-    PollingCaller().start_polling()
-
-    # 防止服务主线程退出
+    """@deprecated: 使用 PollManager 代替"""
+    logger.warning("poll_service() 已废弃，请使用 PollManager")
+    mgr = PollManager(threading.Event())
+    mgr.start()
     try:
         threading.Event().wait()
     except KeyboardInterrupt:
-        logger.warning("服务手动终止: 退出 BangumiKomga 服务")
+        logger.warning("服务手动终止")
+

--- a/services/polling_service.py
+++ b/services/polling_service.py
@@ -1,6 +1,8 @@
+import logging
 import threading
 import time
-from tools.log import logger
+
+logger = logging.getLogger(__name__)
 from config.config import (
     BANGUMI_KOMGA_SERVICE_POLL_INTERVAL,
     BANGUMI_KOMGA_SERVICE_POLL_REFRESH_ALL_METADATA_INTERVAL,

--- a/services/service_runner.py
+++ b/services/service_runner.py
@@ -47,6 +47,7 @@ def run_poll_service(archive_thread):
 def run_sse_service(archive_thread):
     """运行SSE服务"""
     # 启动主服务线程
+    # FIXME: 目前SSE服务的守护线程在所有非守护线程退出后会被强制终止
     service_thread = threading.Thread(
         target=sse_service, daemon=True, name="SSEService"
     )
@@ -58,6 +59,7 @@ def run_sse_service(archive_thread):
 
 def run_once_service():
     """运行一次性服务"""
+    # FIXME: 目前一次性服务未实现完整功能
     pass
 
 

--- a/services/service_runner.py
+++ b/services/service_runner.py
@@ -1,6 +1,8 @@
+import logging
 import threading
 import signal
-from tools.log import logger
+
+logger = logging.getLogger(__name__)
 from config.config import BANGUMI_KOMGA_SERVICE_TYPE
 from core.refresh_metadata import refresh_metadata
 from bangumi_archive.periodic_archive_checker import periodical_archive_check_service
@@ -44,7 +46,7 @@ def _run_once_mode():
     # 同步执行 Archive 检查 (不再用 daemon 线程，防止被提前杀死)
     archive_thread = periodical_archive_check_service()
     if archive_thread is not None:
-        archive_thread.join(timeout=600)  # 最多等 10 分钟
+        archive_thread.join(timeout=1200)  # 最多等 20 分钟，照顾低速网络
 
     logger.info("once 模式执行完毕")
 
@@ -55,8 +57,8 @@ def _run_once_mode():
 def _run_poll_mode():
     stop_event = threading.Event()
 
-    # 启动 Archive 定时检查
-    archive_thread = periodical_archive_check_service()
+    # 启动 Archive 定时检查 (传入 stop_event，支持可中断等待)
+    archive_thread = periodical_archive_check_service(stop_event)
 
     # 启动轮询管理器 (单层 daemon 线程)
     poll_mgr = PollManager(stop_event)
@@ -74,7 +76,9 @@ def _run_poll_mode():
     logger.info("正在停止服务...")
     poll_mgr.stop()
     if archive_thread is not None:
-        archive_thread.join(timeout=10)
+        archive_thread.join(timeout=60)
+        if archive_thread.is_alive():
+            logger.warning("Archive 检查线程未能及时停止，将被强制终止")
     logger.info("BangumiKomga 服务已停止")
 
 
@@ -84,8 +88,8 @@ def _run_poll_mode():
 def _run_sse_mode():
     stop_event = threading.Event()
 
-    # 启动 Archive 定时检查
-    archive_thread = periodical_archive_check_service()
+    # 启动 Archive 定时检查 (传入 stop_event，支持可中断等待)
+    archive_thread = periodical_archive_check_service(stop_event)
 
     # 启动 SSE 管理器 (单层 daemon 线程，内部管理 KomgaSseApi 生命周期)
     sse_mgr = SseManager(stop_event)
@@ -103,7 +107,9 @@ def _run_sse_mode():
     logger.info("正在停止服务...")
     sse_mgr.stop()
     if archive_thread is not None:
-        archive_thread.join(timeout=10)
+        archive_thread.join(timeout=60)
+        if archive_thread.is_alive():
+            logger.warning("Archive 检查线程未能及时停止，将被强制终止")
     logger.info("BangumiKomga 服务已停止")
 
 

--- a/services/service_runner.py
+++ b/services/service_runner.py
@@ -36,7 +36,7 @@ def run_poll_service(archive_thread):
     """运行轮询服务"""
     # 启动主服务线程
     service_thread = threading.Thread(
-        target=poll_service, daemon=True, name="PollService"
+        target=poll_service, name="PollService"
     )
     service_thread.start()
 
@@ -49,7 +49,7 @@ def run_sse_service(archive_thread):
     # 启动主服务线程
     # FIXME: 目前SSE服务的守护线程在所有非守护线程退出后会被强制终止
     service_thread = threading.Thread(
-        target=sse_service, daemon=True, name="SSEService"
+        target=sse_service, name="SSEService"
     )
     service_thread.start()
 

--- a/services/service_runner.py
+++ b/services/service_runner.py
@@ -1,83 +1,125 @@
-from services.polling_service import poll_service
-from services.sse_service import sse_service
-from tools.log import logger
 import threading
+import signal
+from tools.log import logger
 from config.config import BANGUMI_KOMGA_SERVICE_TYPE
 from core.refresh_metadata import refresh_metadata
 from bangumi_archive.periodic_archive_checker import periodical_archive_check_service
+from services.polling_service import PollManager
+from services.sse_service import SseManager
 
 
 def run_service():
-    """
-    启动 Bangumi Komga 服务
-    """
+    """启动 Bangumi Komga 服务"""
     service_type = BANGUMI_KOMGA_SERVICE_TYPE.lower()
 
-    # 启动Archive检查服务
+    if service_type not in ("once", "poll", "sse"):
+        logger.error("无效的服务类型: '%s'，请检查配置文件", BANGUMI_KOMGA_SERVICE_TYPE)
+        return
+
+    # ===========================================================
+    # 首次全量刷新 (try/except 包裹，失败不崩溃)
+    # ===========================================================
+    try:
+        refresh_metadata()
+    except Exception:
+        logger.exception("首次全量刷新失败，服务将继续运行")
+
+    # ===========================================================
+    # 按模式启动
+    # ===========================================================
+    if service_type == "once":
+        _run_once_mode()
+    elif service_type == "poll":
+        _run_poll_mode()
+    elif service_type == "sse":
+        _run_sse_mode()
+
+
+# ---------------------------------------------------------------------------
+# once 模式: 单次全量刷新后退出 (适配 oflia / cron 等外部调度器)
+# ---------------------------------------------------------------------------
+def _run_once_mode():
+    logger.info("once 模式: 等待 Archive 检查完成...")
+
+    # 同步执行 Archive 检查 (不再用 daemon 线程，防止被提前杀死)
+    archive_thread = periodical_archive_check_service()
+    if archive_thread is not None:
+        archive_thread.join(timeout=600)  # 最多等 10 分钟
+
+    logger.info("once 模式执行完毕")
+
+
+# ---------------------------------------------------------------------------
+# poll 模式: 定时轮询 Komga API
+# ---------------------------------------------------------------------------
+def _run_poll_mode():
+    stop_event = threading.Event()
+
+    # 启动 Archive 定时检查
     archive_thread = periodical_archive_check_service()
 
-    refresh_metadata()
+    # 启动轮询管理器 (单层 daemon 线程)
+    poll_mgr = PollManager(stop_event)
+    poll_mgr.start()
 
-    if service_type == "poll":
-        run_poll_service(archive_thread)
-    elif service_type == "sse":
-        run_sse_service(archive_thread)
-    elif service_type == "once":
-        run_once_service()
-    else:
-        logger.error(
-            "无效的服务类型: '%s'，请检查配置文件",
-            BANGUMI_KOMGA_SERVICE_TYPE,
-        )
-        exit(1)
+    # 注册信号处理 (SIGINT/SIGTERM → set stop_event)
+    _setup_stop_signals(stop_event)
 
+    logger.info("poll 模式已启动，等待停止信号...")
 
-def run_poll_service(archive_thread):
-    """运行轮询服务"""
-    # 启动主服务线程
-    service_thread = threading.Thread(
-        target=poll_service, name="PollService"
-    )
-    service_thread.start()
+    # 阻塞直到收到停止信号
+    stop_event.wait()
 
-    # 等待服务结束
-    wait_for_services(service_thread, archive_thread)
+    # 清理
+    logger.info("正在停止服务...")
+    poll_mgr.stop()
+    if archive_thread is not None:
+        archive_thread.join(timeout=10)
+    logger.info("BangumiKomga 服务已停止")
 
 
-def run_sse_service(archive_thread):
-    """运行SSE服务"""
-    # 启动主服务线程
-    # FIXME: 目前SSE服务的守护线程在所有非守护线程退出后会被强制终止
-    service_thread = threading.Thread(
-        target=sse_service, name="SSEService"
-    )
-    service_thread.start()
+# ---------------------------------------------------------------------------
+# sse 模式: 订阅 Komga SSE 事件流
+# ---------------------------------------------------------------------------
+def _run_sse_mode():
+    stop_event = threading.Event()
 
-    # 等待服务结束
-    wait_for_services(service_thread, archive_thread)
+    # 启动 Archive 定时检查
+    archive_thread = periodical_archive_check_service()
+
+    # 启动 SSE 管理器 (单层 daemon 线程，内部管理 KomgaSseApi 生命周期)
+    sse_mgr = SseManager(stop_event)
+    sse_mgr.start()
+
+    # 注册信号处理
+    _setup_stop_signals(stop_event)
+
+    logger.info("sse 模式已启动，等待停止信号...")
+
+    # 阻塞直到收到停止信号
+    stop_event.wait()
+
+    # 清理
+    logger.info("正在停止服务...")
+    sse_mgr.stop()
+    if archive_thread is not None:
+        archive_thread.join(timeout=10)
+    logger.info("BangumiKomga 服务已停止")
 
 
-def run_once_service():
-    """运行一次性服务"""
-    # FIXME: 目前一次性服务未实现完整功能
-    pass
+# ---------------------------------------------------------------------------
+# 信号处理 (SIGINT / SIGTERM)
+# ---------------------------------------------------------------------------
+def _setup_stop_signals(stop_event):
+    """在主线程注册 SIGINT 和 SIGTERM 的优雅停止处理器"""
+    def _handler(signum, frame):
+        sig_name = signal.Signals(signum).name
+        logger.info("收到信号 %s，正在停止服务...", sig_name)
+        stop_event.set()
 
-
-def wait_for_services(service_thread, archive_thread=None):
-    """
-    等待服务线程结束
-
-    Args:
-        service_thread: 主服务线程
-        archive_thread: Archive检查线程（可选）
-    """
-    try:
-        # 等待主服务线程结束
-        service_thread.join()
-        # 如果有Archive线程，等待其结束
-        if archive_thread is not None:
-            archive_thread.join()
-    except KeyboardInterrupt:
-        logger.warning("服务手动终止: 退出 BangumiKomga 服务")
-    finally:
-        logger.info("BangumiKomga 服务已停止")
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            signal.signal(sig, _handler)
+        except (ValueError, OSError):
+            # 非主线程或受限环境（如某些 Docker 配置）中无法设置
+            logger.debug("无法为 %s 注册信号处理器", sig.name)

--- a/services/sse_service.py
+++ b/services/sse_service.py
@@ -1,6 +1,8 @@
+import logging
 import threading
 import time
-from tools.log import logger
+
+logger = logging.getLogger(__name__)
 from config.config import KOMGA_LIBRARY_LIST
 from core.refresh_metadata import refresh_metadata, get_series_metadata
 from api.komga_sse_api import KomgaSseApi

--- a/services/sse_service.py
+++ b/services/sse_service.py
@@ -1,62 +1,142 @@
 import threading
+import time
 from tools.log import logger
-
 from config.config import KOMGA_LIBRARY_LIST
 from core.refresh_metadata import refresh_metadata, get_series_metadata
 from api.komga_sse_api import KomgaSseApi
-import threading
-
-# FIXME: 监听了库内容变化, 但没有关注收藏集的内容变化
 
 
+class SseManager:
+    """SSE 管理器 — 单层 daemon 线程监控连接健康，断线无限重连"""
+
+    def __init__(self, stop_event):
+        self._stop_event = stop_event
+        self._thread = None
+        self._sse_api = None
+
+    def start(self):
+        """启动 SSE 管理线程"""
+        if self._thread and self._thread.is_alive():
+            logger.warning("SseManager 已在运行")
+            return
+        self._thread = threading.Thread(
+            target=self._run, daemon=True, name="SseManager"
+        )
+        self._thread.start()
+        logger.info("SseManager 已启动")
+
+    def stop(self):
+        """停止 SSE 管理"""
+        self._stop_event.set()
+        if self._sse_api is not None:
+            try:
+                self._sse_api._stop_client()
+            except Exception:
+                logger.exception("停止 SSE 客户端时出错")
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=10)
+        logger.info("SseManager 已停止")
+
+    # ------------------------------------------------------------------
+    # 主循环
+    # ------------------------------------------------------------------
+    def _run(self):
+        """监控 SSE 连接线程，死亡时自动重建 (指数退避，无上限)"""
+        consecutive_failures = 0
+
+        while not self._stop_event.is_set():
+            try:
+                # 创建新的 SSE API 实例 (构造函数会自动启动 SSE 连接)
+                self._sse_api = KomgaSseApi()
+                self._sse_api.register_series_update_callback(_series_update_handler)
+                logger.info("SSE 客户端已创建并启动")
+
+                # 监控 SSE 客户端线程是否存活
+                while not self._stop_event.is_set():
+                    client_thread = getattr(self._sse_api.sse_client, 'thread', None)
+                    if client_thread is None or not client_thread.is_alive():
+                        logger.warning("检测到 SSE 客户端线程退出")
+                        break
+                    self._stop_event.wait(2)  # 每 2 秒检查一次
+
+                # 如果是因为 stop_event 退出，不再重连
+                if self._stop_event.is_set():
+                    break
+
+                consecutive_failures += 1
+
+            except Exception:
+                logger.exception("SseManager 异常")
+                consecutive_failures += 1
+
+            # 停止旧实例
+            if self._sse_api is not None:
+                try:
+                    self._sse_api._stop_client()
+                except Exception:
+                    pass
+                self._sse_api = None
+
+            if self._stop_event.is_set():
+                break
+
+            # 指数退避 (1s → 2s → 4s → ... → 60s 封顶)
+            backoff = min(2 ** consecutive_failures, 60)
+            logger.info("SSE 将在 %d 秒后重连 (第 %d 次)", backoff, consecutive_failures)
+            self._stop_event.wait(backoff)
+
+
+# ---------------------------------------------------------------------------
+# SSE 事件处理器 (模块级函数，避免持有 SseManager 引用)
+# ---------------------------------------------------------------------------
 def _is_surveilled_library(library_id):
     if KOMGA_LIBRARY_LIST:
         KOMGA_LIBRARIES = {item["LIBRARY"] for item in KOMGA_LIBRARY_LIST}
         return library_id not in KOMGA_LIBRARIES
-    else:
-        return False
+    return False
 
 
-def series_update_sse_handler(data):
-    # TODO: 处理 series_id, library_id 或者 series_detail 的场景
+def _series_update_handler(data):
+    """处理 Komga SSE 系列更新事件"""
     series_id = data["event_data"]["seriesId"]
     library_id = data["event_data"]["libraryId"]
-    # 获取指定系列的详细信息
-    series_detail = get_series_metadata([series_id])
+
+    try:
+        series_detail = get_series_metadata([series_id])
+    except Exception:
+        logger.exception("获取系列元数据失败: %s", series_id)
+        return
+
     # 筛选有效的 SeriesChanged 事件
     if data["event_type"] == "SeriesChanged":
-        # 判断 SeriesChanged 是否为CBL更改
-        # 或者该系列并未匹配元数据
-        if any(
-            link["label"].lower() == "cbl"
-            for link in series_detail[0]["metadata"]["links"]
-        ):
-            pass
-        else:
-            # 无视其他 SeriesChanged 事件
+        try:
+            if not any(
+                link["label"].lower() == "cbl"
+                for link in series_detail[0]["metadata"]["links"]
+            ):
+                return  # 无 CBL 链接，忽略
+        except (IndexError, KeyError):
             return
-    # 其他事件 RefreshEventType, 例如 SeriesAdded
-    else:
-        pass
-    # 设置了 KOMGA_LIBRARY_LIST 且 library_id 不在 KOMGA_LIBRARY_LIST 中
+
     if _is_surveilled_library(library_id):
-        logger.info("未找到最近添加系列, 无需刷新")
-    # 未设置 KOMGA_LIBRARY_LIST或 library_id 在 KOMGA_LIBRARY_LIST 中, 以 series_detail 刷新指定库中的系列
+        logger.info("library %s 不在监控范围内，跳过", library_id)
     else:
-        refresh_metadata(series_detail)
-    return
+        try:
+            refresh_metadata(series_detail)
+        except Exception:
+            logger.exception("刷新元数据失败")
 
 
+# ---------------------------------------------------------------------------
+# 向后兼容入口 (已废弃)
+# ---------------------------------------------------------------------------
 def sse_service():
-    komga_api = KomgaSseApi()
-
-    # 注册回调函数
-    komga_api.register_series_update_callback(series_update_sse_handler)
-
-    # 防止服务主线程退出
+    """@deprecated: 使用 SseManager 代替"""
+    logger.warning("sse_service() 已废弃，请使用 SseManager")
+    mgr = SseManager(threading.Event())
+    mgr.start()
     try:
         threading.Event().wait()
     except KeyboardInterrupt:
-        # 取消注册
-        komga_api.unregister_series_update_callback(series_update_sse_handler)
-        logger.warning("服务手动终止: 退出 BangumiKomga 服务")
+        logger.warning("服务手动终止")
+        mgr.stop()

--- a/tools/cache_time.py
+++ b/tools/cache_time.py
@@ -1,7 +1,9 @@
+import logging
 import json
 from datetime import datetime, timedelta
 from typing import Optional
-from tools.log import logger
+
+logger = logging.getLogger(__name__)
 
 
 class TimeCacheManager:

--- a/tools/db.py
+++ b/tools/db.py
@@ -1,6 +1,8 @@
+import logging
 import sqlite3
 from time import strftime, localtime
-from tools.log import logger
+
+logger = logging.getLogger(__name__)
 
 
 def upsert_series_record(

--- a/tools/env.py
+++ b/tools/env.py
@@ -1,9 +1,11 @@
+import logging
 from api.bangumi_api import BangumiDataSourceFactory
 import api.komga_api as komga_api
 from config.config import *
 import os
 import sqlite3
-from tools.log import logger
+
+logger = logging.getLogger(__name__)
 from config.configuration_generator import start_config_generate
 
 

--- a/tools/log.py
+++ b/tools/log.py
@@ -3,31 +3,40 @@ import logging
 from logging.handlers import RotatingFileHandler
 
 
+# 配置根 logger
+_logger = logging.getLogger()
+_logger.setLevel(logging.INFO)
+
+
 def is_in_debug():
     """检测是否在调试模式下运行"""
     result = sys.gettrace()
-    logger.debug(f"调试器检测结果: {result}")
+    _logger.debug(f"调试器检测结果: {result}")
     return bool(result)
 
 
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
-formatter = logging.Formatter(
-    "%(asctime)s - %(name)s - %(levelname)s - %(filename)-8s : %(lineno)s - %(message)s"
-)
+# pytest: module 集合时 "pytest" 已在 sys.modules；unittest: test_ 前缀文件在此进程arg中
+_in_test = "pytest" in sys.modules
 
-fh = RotatingFileHandler(
-    filename="logs/refreshMetadata.log",
-    maxBytes=10000000,
-    backupCount=9,
-    encoding="utf-8",
-)
-fh.setFormatter(formatter)
-fh.setLevel(logging.INFO)
-logger.addHandler(fh)
+if not _in_test:
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(filename)-8s : %(lineno)s - %(message)s"
+    )
 
-sh = logging.StreamHandler(sys.stdout)
-sh.setFormatter(formatter)
-# 感知调试器, 切换日志等级
-sh.setLevel(logging.DEBUG if is_in_debug() else logging.INFO)
-logger.addHandler(sh)
+    fh = RotatingFileHandler(
+        filename="logs/refreshMetadata.log",
+        maxBytes=10000000,
+        backupCount=9,
+        encoding="utf-8",
+    )
+    fh.setFormatter(formatter)
+    fh.setLevel(logging.INFO)
+    _logger.addHandler(fh)
+
+    sh = logging.StreamHandler(sys.stdout)
+    sh.setFormatter(formatter)
+    sh.setLevel(logging.DEBUG if is_in_debug() else logging.INFO)
+    _logger.addHandler(sh)
+
+# 向后兼容：仍然暴露 logger
+logger = _logger

--- a/tools/notification.py
+++ b/tools/notification.py
@@ -1,7 +1,9 @@
+import logging
 import json
 import requests
 from config.config import *
-from tools.log import logger
+
+logger = logging.getLogger(__name__)
 
 
 def send_notification(title, message):

--- a/tools/slide_window_rate_limiter.py
+++ b/tools/slide_window_rate_limiter.py
@@ -1,7 +1,9 @@
+import logging
 import time
 from collections import deque
 from functools import wraps
-from tools.log import logger
+
+logger = logging.getLogger(__name__)
 
 
 class SlideWindowCounter:


### PR DESCRIPTION
依赖于 https://github.com/chu-shen/BangumiKomga/pull/149

尝试将项目中所有模块从自定义 `tools.log.logger` 迁移到 Python 标准库 `logging`，
降低模块间耦合，便于测试。
同时重构服务管理层并修复多个 API 异常处理 bug。


- 全项目统一使用 `logging.getLogger(__name__)` 替代自定义 logger
- 涉及模块: `api/`, `core/`, `services/`, `scripts/`, `bangumi_archive/`, `tools/`
- 重构 `tools/log.py`：增加 pytest 检测，避免测试时重复添加 Handler
- 保留 `logger` 变量名以维持向后兼容
- 归档索引保存改为"写临时文件 + `os.replace()`"模式
- 防止进程异常中断导致索引文件半写入损坏
- 引入 `PollManager` 和 `SseManager` 替代旧版轮询机制
- 更新 `service_runner.py` 适配新管理器
- `.gitignore` 添加 `logs/*`