### PR TITLE
ci(test): 给dev分支添加CI单元测试

### DIFF
--- a/.github/workflows/unitest-ci.yml
+++ b/.github/workflows/unitest-ci.yml
@@ -2,9 +2,9 @@ name: Unittest CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, dev ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ main, dev ]
 jobs:
   auto-unit-test:
     runs-on: ubuntu-latest

--- a/tests/test_komga_sse_api.py
+++ b/tests/test_komga_sse_api.py
@@ -19,7 +19,7 @@ class TestKomgaSseClient(unittest.TestCase):
 
         # 模拟日志系统
         self.mock_logger = MagicMock()
-        patch('tools.log.logger', self.mock_logger).start()
+        patch('api.komga_sse_api.logger', self.mock_logger).start()
 
         # 模拟requests.Session
         self.session_mock = MagicMock()
@@ -127,7 +127,7 @@ class TestKomgaSseApi(unittest.TestCase):
 
         # 模拟日志系统
         self.mock_logger = MagicMock()
-        patch('tools.log.logger', self.mock_logger).start()
+        patch('api.komga_sse_api.logger', self.mock_logger).start()
 
         # 模拟requests.Session
         self.session_mock = MagicMock()
@@ -262,7 +262,7 @@ class TestErrorHandling(unittest.TestCase):
 
         # 模拟日志系统
         self.mock_logger = MagicMock()
-        patch('tools.log.logger', self.mock_logger).start()
+        patch('api.komga_sse_api.logger', self.mock_logger).start()
 
         # 模拟requests.Session
         self.session_mock = MagicMock()

--- a/tests/test_komga_sse_api.py
+++ b/tests/test_komga_sse_api.py
@@ -3,62 +3,65 @@ from unittest.mock import MagicMock, patch
 from api.komga_sse_api import KomgaSseClient, KomgaSseApi, RefreshEventType
 
 
-# @unittest.skip("临时跳过测试")
-class TestKomgaSseClient(unittest.TestCase):
-    """基于Mock的Komga SSE测试"""
+class BaseKomgaSseTest(unittest.TestCase):
+    """共享的 Komga SSE 测试基类 —— 封装 logger / Session / Response 的 mock 设置。"""
 
     def setUp(self):
-        # 模拟配置
         self.base_url = "http://mocked-komga-url"
         self.username = "test_user"
         self.password = "test_password"
 
-        # 模拟requests.get，防止真实认证请求
-        self.mock_get_patcher = patch('requests.get')
-        self.mock_get = self.mock_get_patcher.start()
-
-        # 模拟日志系统
+        # 模拟日志系统（一处定义，子类复用）
         self.mock_logger = MagicMock()
         patch('api.komga_sse_api.logger', self.mock_logger).start()
 
-        # 模拟requests.Session
+        # 模拟 requests.Session
         self.session_mock = MagicMock()
         self.session_mock.headers = {}
-        self.session_constructor = patch(
-            'requests.Session', return_value=self.session_mock).start()
+        patch('requests.Session', return_value=self.session_mock).start()
 
-        # 模拟Response对象
+        # 模拟 Response 对象
         self.response_mock = MagicMock()
         self.response_mock.status_code = 200
         self.response_mock.headers = {}
         self.session_mock.get.return_value = self.response_mock
 
-        # 准备测试事件数据
-        self.test_events = [
-            # 单行事件块
-            'event: SeriesAdded\ndata: {"id":"series1", "libraryId":"0JR3B78BEGVYG"}\n\n',
-            # 多行数据事件
-            'event: BookAdded\ndata: {"id":"book1", "seriesId":"series1"}\n'
-            'data: {"libraryId":"0JR3B78BEGVYG"}\n\n',
-            # 不完整数据块
-            'event: SeriesChanged\ndata: {"id":"series2"',
-            # 多行数据中的后继数据块
-            'data: {"libraryId":"0JR3B78BEGVYG"}\n\n',
-            # 无效事件类型
-            'event: UnknownEvent\ndata: {"test":true}\n\n'
-        ]
-        # 模拟真实字节流传输
-        self.test_event_bytes = [event.encode(
-            'utf-8') for event in self.test_events]
+    def tearDown(self):
+        patch.stopall()
+
+    def _setup_test_events(self, events=None):
+        """配置 mock response 以返回指定的 SSE 事件数据。"""
+        if events is None:
+            events = [
+                # 单行事件块
+                'event: SeriesAdded\ndata: {"id":"series1", "libraryId":"0JR3B78BEGVYG"}\n\n',
+                # 多行数据事件
+                'event: BookAdded\ndata: {"id":"book1", "seriesId":"series1"}\n'
+                'data: {"libraryId":"0JR3B78BEGVYG"}\n\n',
+                # 不完整数据块
+                'event: SeriesChanged\ndata: {"id":"series2"',
+                # 多行数据中的后继数据块
+                'data: {"libraryId":"0JR3B78BEGVYG"}\n\n',
+                # 无效事件类型
+                'event: UnknownEvent\ndata: {"test":true}\n\n'
+            ]
+        self.test_events = events
+        self.test_event_bytes = [e.encode('utf-8') for e in events]
         self.response_mock.iter_lines.side_effect = lambda chunk_size, decode_unicode: iter(
             self.test_event_bytes)
 
-        # 创建不会发起真实请求的测试客户端
+
+# @unittest.skip("临时跳过测试")
+class TestKomgaSseClient(BaseKomgaSseTest):
+    """基于Mock的Komga SSE测试"""
+
+    def setUp(self):
+        super().setUp()
+        # 防止真实认证请求
+        patch('requests.get').start()
+        self._setup_test_events()
         self.client = KomgaSseClient(
             self.base_url, self.username, self.password)
-
-    def tearDown(self):
-        patch.stopall()
 
     def test_authentication_flow(self):
         """测试SSE Client - 模拟认证流程"""
@@ -114,53 +117,12 @@ class TestKomgaSseClient(unittest.TestCase):
 
 
 # @unittest.skip("临时跳过测试")
-class TestKomgaSseApi(unittest.TestCase):
+class TestKomgaSseApi(BaseKomgaSseTest):
     def setUp(self):
-        # 模拟配置
-        self.base_url = "http://mocked-komga-url"
-        self.username = "test_user"
-        self.password = "test_password"
-
-        # 模拟requests.get，防止真实认证请求
-        self.mock_get_patcher = patch('requests.get')
-        self.mock_get = self.mock_get_patcher.start()
-
-        # 模拟日志系统
-        self.mock_logger = MagicMock()
-        patch('api.komga_sse_api.logger', self.mock_logger).start()
-
-        # 模拟requests.Session
-        self.session_mock = MagicMock()
-        self.session_constructor = patch(
-            'requests.Session', return_value=self.session_mock).start()
-
-        # 模拟Response对象
-        self.response_mock = MagicMock()
-        self.response_mock.status_code = 200
-        self.response_mock.headers = {}
-        self.session_mock.get.return_value = self.response_mock
-
-        # 准备测试事件数据
-        self.test_events = [
-            # 单行事件块
-            'event: SeriesAdded\ndata: {"id":"series1", "libraryId":"0JR3B78BEGVYG"}\n\n',
-            # 多行数据事件
-            'event: BookAdded\ndata: {"id":"book1", "seriesId":"series1"}\n'
-            'data: {"libraryId":"0JR3B78BEGVYG"}\n\n',
-            # 不完整数据块
-            'event: SeriesChanged\ndata: {"id":"series2"',
-            # 多行数据中的后继数据块
-            'data: {"libraryId":"0JR3B78BEGVYG"}\n\n',
-            # 无效事件类型
-            'event: UnknownEvent\ndata: {"test":true}\n\n'
-        ]
-
-        # 模拟真实字节流传输
-        self.test_event_bytes = [event.encode(
-            'utf-8') for event in self.test_events]
-        self.response_mock.iter_lines.side_effect = lambda chunk_size, decode_unicode: iter(
-            self.test_event_bytes)
-
+        super().setUp()
+        # 防止真实认证请求
+        patch('requests.get').start()
+        self._setup_test_events()
         # 创建不会发起真实请求的API实例
         self.api = KomgaSseApi(
             self.base_url, self.username, self.password)
@@ -247,43 +209,14 @@ class TestKomgaSseApi(unittest.TestCase):
 
 
 # @unittest.skip("临时跳过测试")
-class TestErrorHandling(unittest.TestCase):
+class TestErrorHandling(BaseKomgaSseTest):
     """错误处理测试"""
 
     def setUp(self):
-        # 模拟配置
-        self.base_url = "http://mocked-komga-url"
-        self.username = "test_user"
-        self.password = "test_password"
-
-        # 模拟requests.post，防止真实认证请求
-        self.mock_post_patcher = patch('requests.post')
-        self.mock_post = self.mock_post_patcher.start()
-
-        # 模拟日志系统
-        self.mock_logger = MagicMock()
-        patch('api.komga_sse_api.logger', self.mock_logger).start()
-
-        # 模拟requests.Session
-        self.session_mock = MagicMock()
-        self.session_constructor = patch(
-            'requests.Session', return_value=self.session_mock).start()
-
-        # 模拟Response对象
-        self.response_mock = MagicMock()
-        self.response_mock.status_code = 200
-        self.response_mock.headers = {}
-        self.session_mock.get.return_value = self.response_mock
-
-        self.test_events = []
-
-        # 模拟真实字节流传输
-        self.test_event_bytes = [event.encode(
-            'utf-8') for event in self.test_events]
-        self.response_mock.iter_lines.side_effect = lambda chunk_size, decode_unicode: iter(
-            self.test_event_bytes)
-
-        # 创建不会发起真实请求的测试客户端
+        super().setUp()
+        # 防止真实认证请求
+        patch('requests.post').start()
+        self._setup_test_events(events=[])
         self.client = KomgaSseClient(
             self.base_url, self.username, self.password)
 

--- a/tests/test_tools_cache_time.py
+++ b/tests/test_tools_cache_time.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from pathlib import Path
 from tempfile import TemporaryDirectory
 import logging
-logger = logging.getLogger(__name__)
 from tools.cache_time import TimeCacheManager
 
 
@@ -44,7 +43,7 @@ class TestTimeCacheManager(unittest.TestCase):
         """测试时间缓存管理器 - 文件不存在的情况"""
         non_existent_file = str(Path(self.temp_dir.name) / "nonexistent.json")
 
-        with self.assertLogs(logger, level='WARNING') as cm:
+        with self.assertLogs(logging.getLogger('tools.cache_time'), level='WARNING') as cm:
             result = TimeCacheManager.read_time(non_existent_file)
             self.assertEqual(result, self.default_time)
             self.assertIn("不存在，使用默认时间", cm.output[0])
@@ -55,7 +54,7 @@ class TestTimeCacheManager(unittest.TestCase):
         with open(self.test_file, 'w') as f:
             f.write("invalid json")
 
-        with self.assertLogs(logger, level='WARNING') as cm:
+        with self.assertLogs(logging.getLogger('tools.cache_time'), level='WARNING') as cm:
             result = TimeCacheManager.read_time(str(self.test_file))
             self.assertEqual(result, self.default_time)
             self.assertIn("解析失败", cm.output[0])
@@ -101,7 +100,7 @@ class TestTimeCacheManager(unittest.TestCase):
         """测试时间缓存管理器 - 无效时间格式"""
         time_str = "invalid-time-format"
 
-        with self.assertLogs(logger, level='WARNING') as cm:
+        with self.assertLogs(logging.getLogger('tools.cache_time'), level='WARNING') as cm:
             result = TimeCacheManager.convert_to_datetime(time_str)
             self.assertIsNone(result)
             # 检查日志是否包含关键信息（推荐使用 in 判断多个关键词）

--- a/tests/test_tools_cache_time.py
+++ b/tests/test_tools_cache_time.py
@@ -3,8 +3,7 @@ import json
 from datetime import datetime
 from pathlib import Path
 from tempfile import TemporaryDirectory
-import logging
-from tools.cache_time import TimeCacheManager
+from tools.cache_time import TimeCacheManager, logger
 
 
 class TestTimeCacheManager(unittest.TestCase):
@@ -43,7 +42,7 @@ class TestTimeCacheManager(unittest.TestCase):
         """测试时间缓存管理器 - 文件不存在的情况"""
         non_existent_file = str(Path(self.temp_dir.name) / "nonexistent.json")
 
-        with self.assertLogs(logging.getLogger('tools.cache_time'), level='WARNING') as cm:
+        with self.assertLogs(logger, level='WARNING') as cm:
             result = TimeCacheManager.read_time(non_existent_file)
             self.assertEqual(result, self.default_time)
             self.assertIn("不存在，使用默认时间", cm.output[0])
@@ -54,7 +53,7 @@ class TestTimeCacheManager(unittest.TestCase):
         with open(self.test_file, 'w') as f:
             f.write("invalid json")
 
-        with self.assertLogs(logging.getLogger('tools.cache_time'), level='WARNING') as cm:
+        with self.assertLogs(logger, level='WARNING') as cm:
             result = TimeCacheManager.read_time(str(self.test_file))
             self.assertEqual(result, self.default_time)
             self.assertIn("解析失败", cm.output[0])
@@ -100,7 +99,7 @@ class TestTimeCacheManager(unittest.TestCase):
         """测试时间缓存管理器 - 无效时间格式"""
         time_str = "invalid-time-format"
 
-        with self.assertLogs(logging.getLogger('tools.cache_time'), level='WARNING') as cm:
+        with self.assertLogs(logger, level='WARNING') as cm:
             result = TimeCacheManager.convert_to_datetime(time_str)
             self.assertIsNone(result)
             # 检查日志是否包含关键信息（推荐使用 in 判断多个关键词）


### PR DESCRIPTION
- 给dev分支添加CI单元测试

## Summary by Sourcery

优化 Komga SSE 相关的单元测试，并扩展 unittest CI 工作流以覆盖 dev 分支。

Bug 修复：
- 确保 Komga SSE 测试对正确的 logger 实例进行 patch 和断言。
- 更新缓存时间（cache time）测试，改为使用 `cache_time` 模块中的 logger，而不是本地创建的 logger。

增强：
- 引入一个共享的 Komga SSE 测试基类，用于集中管理 logger、session 和 response 的模拟。

CI：
- 更新 Unittest CI 的 GitHub Actions 工作流，使其在针对 `main` 和 `dev` 分支的 push 和 pull request 时运行。

测试：
- 将 Komga SSE 客户端、API 和错误处理测试统一迁移到共享的测试基类上，以减少测试设置中的重复代码。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine Komga SSE-related unit tests and extend the unittest CI workflow to cover the dev branch.

Bug Fixes:
- Ensure Komga SSE tests patch and assert against the correct logger instance.
- Update cache time tests to use the logger from the cache_time module instead of a locally created logger.

Enhancements:
- Introduce a shared Komga SSE test base class to centralize logger, session, and response mocking.

CI:
- Update the Unittest CI GitHub Actions workflow to run on pushes and pull requests targeting both main and dev branches.

Tests:
- Consolidate Komga SSE client, API, and error-handling tests onto the shared base class to reduce duplication in test setup.

</details>

Bug 修复：
- 调整 Komga SSE API 测试，以修补正确的日志记录器实例。
- 更新缓存时间测试，以针对适当命名的日志记录器断言日志输出。

CI：
- 扩展单元测试的 GitHub Actions 工作流，使其在推送和针对 dev 分支的拉取请求上运行，除了 main 分支之外。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

优化 Komga SSE 相关的单元测试，并扩展 unittest CI 工作流以覆盖 dev 分支。

Bug 修复：
- 确保 Komga SSE 测试对正确的 logger 实例进行 patch 和断言。
- 更新缓存时间（cache time）测试，改为使用 `cache_time` 模块中的 logger，而不是本地创建的 logger。

增强：
- 引入一个共享的 Komga SSE 测试基类，用于集中管理 logger、session 和 response 的模拟。

CI：
- 更新 Unittest CI 的 GitHub Actions 工作流，使其在针对 `main` 和 `dev` 分支的 push 和 pull request 时运行。

测试：
- 将 Komga SSE 客户端、API 和错误处理测试统一迁移到共享的测试基类上，以减少测试设置中的重复代码。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine Komga SSE-related unit tests and extend the unittest CI workflow to cover the dev branch.

Bug Fixes:
- Ensure Komga SSE tests patch and assert against the correct logger instance.
- Update cache time tests to use the logger from the cache_time module instead of a locally created logger.

Enhancements:
- Introduce a shared Komga SSE test base class to centralize logger, session, and response mocking.

CI:
- Update the Unittest CI GitHub Actions workflow to run on pushes and pull requests targeting both main and dev branches.

Tests:
- Consolidate Komga SSE client, API, and error-handling tests onto the shared base class to reduce duplication in test setup.

</details>

</details>