### PR TITLE
fix(api & core): 返回类型与异常处理逻辑, 补充类型注解

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 config.py
 recordsRefreshed.db
-refreshMetadata.log
+logs/
 __pycache__/
 .vscode
 *.json*

--- a/README.md
+++ b/README.md
@@ -9,8 +9,11 @@
   - [快速开始](#快速开始)
   - [Komga 配置（必填）](#komga-配置必填)
     - [为小说添加元数据](#为小说添加元数据)
+    - [支持 One-Shots](#支持-one-shots)
   - [Bangumi 配置（可选）](#bangumi-配置可选)
   - [网络代理设置（可选）](#网络代理设置可选)
+    - [Docker compose](#docker-compose)
+    - [原生部署](#原生部署)
   - [消息通知（可选）](#消息通知可选)
   - [创建失败收藏（可选）](#创建失败收藏可选)
   - [其他配置说明](#其他配置说明)
@@ -133,6 +136,10 @@
 Komga 并没有区分漫画与小说，建议不同类型使用不同库
 
 `IS_NOVEL_ONLY`：设置为`True`时，将只匹配小说数据；默认设置为`False`，匹配漫画数据
+
+### 支持 One-Shots
+
+按照[官方文档](https://komga.org/docs/guides/oneshots/)编辑库设置，添加 One-Shots 单行本目录后可正常刮削
 
 ## Bangumi 配置（可选）
 

--- a/api/bangumi_api.py
+++ b/api/bangumi_api.py
@@ -19,8 +19,8 @@ from tools.resort_search_results_list import resort_search_list
 from tools.slide_window_rate_limiter import slide_window_rate_limiter
 from zhconv import convert
 from abc import ABC, abstractmethod
+from typing import Any
 
-# TODO： 在DataSource中添加一个本地缓存目录，将从 API 获取的封面图片保存为文件（如 cache/thumbnails/{subject_id}_{image_size}.jpg），下次直接读取本地文件，避免重复请求
 
 
 class DataSource(ABC):
@@ -29,24 +29,27 @@ class DataSource(ABC):
     """
 
     @abstractmethod
-    def search_subjects(self, query, threshold=80, is_novel=False):
-        pass
+    def search_subjects(self, query: str, threshold: int = 80,
+                        is_novel: bool = False) -> list:
+        ...
 
     @abstractmethod
-    def get_subject_metadata(self, subject_id):
-        pass
+    def get_subject_metadata(self, subject_id: Any) -> dict:
+        ...
 
     @abstractmethod
-    def get_related_subjects(self, subject_id):
-        pass
+    def get_related_subjects(self, subject_id: Any) -> list:
+        ...
 
     @abstractmethod
-    def update_reading_progress(self, subject_id, progress):
-        pass
+    def update_reading_progress(self, subject_id: Any,
+                                progress: Any) -> bool:
+        ...
 
     @abstractmethod
-    def get_subject_thumbnail(self, subject_metadata, image_size):
-        pass
+    def get_subject_thumbnail(self, subject_metadata: dict,
+                              image_size: str) -> dict:
+        ...
 
 
 class BangumiApiDataSource(DataSource):
@@ -123,7 +126,7 @@ class BangumiApiDataSource(DataSource):
             logger.error(
                 f"请检查 {subject_id} 是否填写正确；或属于 NSFW，但并未配置 BANGUMI_ACCESS_TOKEN"
             )
-            return []
+            return {}
         return response.json()
 
     @slide_window_rate_limiter()
@@ -152,6 +155,7 @@ class BangumiApiDataSource(DataSource):
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             logger.error(f"出现错误: {e}")
+            return False
         return response.status_code == 204
 
     @slide_window_rate_limiter()
@@ -172,7 +176,7 @@ class BangumiApiDataSource(DataSource):
             thumbnail = self.r.get(image).content
         except Exception as e:
             logger.error(f"出现错误: {e}")
-            return []
+            return {}
         files = {"file": (subject_metadata["name"], thumbnail)}
         return files
 
@@ -275,6 +279,8 @@ class BangumiArchiveDataSource(DataSource):
                     metadata = self._get_metadata_from_archive(
                         item.get("related_subject_id", 0)
                     )
+                    if not metadata:
+                        continue
                     result = {
                         "name": metadata.get("name"),
                         "name_cn": metadata.get("name_cn"),
@@ -294,15 +300,13 @@ class BangumiArchiveDataSource(DataSource):
         """
         离线数据源更新阅读进度
         """
-        NotImplementedError("离线数据源不支持更新阅读进度")
-        return False
+        raise NotImplementedError("离线数据源不支持更新阅读进度")
 
     def get_subject_thumbnail(self, subject_metadata, image_size):
         """
         离线数据源获取封面
         """
-        NotImplementedError("离线数据源不支持获取封面")
-        return {}
+        raise NotImplementedError("离线数据源不支持获取封面")
 
 
 class BangumiDataSourceFactory:
@@ -356,7 +360,7 @@ class FallbackDataSource(DataSource):
         return self._fallback_call("get_related_subjects", subject_id)
 
     def update_reading_progress(self, subject_id, progress):
-        self._fallback_call("update_reading_progress", subject_id, progress)
+        return self._fallback_call("update_reading_progress", subject_id, progress)
 
     def get_subject_thumbnail(self, subject_metadata, image_size):
         return self._fallback_call(

--- a/api/bangumi_api.py
+++ b/api/bangumi_api.py
@@ -7,7 +7,8 @@ import requests
 from requests.adapters import HTTPAdapter
 
 from api.bangumi_model import BangumiBaseType
-from tools.log import logger
+import logging
+logger = logging.getLogger(__name__)
 from bangumi_archive.local_archive_searcher import (
     parse_infobox,
     search_line,

--- a/api/komga_api.py
+++ b/api/komga_api.py
@@ -244,29 +244,42 @@ class KomgaApi:
         # return the response as a JSON object
         return response.json()
 
-    def update_series_metadata(self, series_id, metadata):
+    def update_metadata(self, id, metadata, metadata_type):
         """
-        Updates the metadata of a specified comic series.
+        Updates the metadata of a specified comic.
         """
         try:
             # make a PATCH request to the URL to update the metadata for a given series
             response = self.r.patch(
-                f"{self.base_url}/series/{series_id}/metadata", json=metadata
+                f"{self.base_url}/{metadata_type}/{id}/metadata", json=metadata
             )
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             logger.error(f"出现错误: {e}")
         # return True if the status code indicates success, False otherwise
         return response.status_code == 204
-
-    def update_series_thumbnail(self, series_id, thumbnail):
+    
+    def update_series_metadata(self, series_id, metadata):
         """
-        Updates the thumbnail of a specified comic series.
+        Updates the metadata of a specified comic series.
+        """
+        return self.update_metadata(series_id, metadata, "series")
+
+    def update_book_metadata(self, book_id, metadata):
+        """
+        Updates the metadata of a specified comic book.
+
+        https://github.com/gotson/komga/blob/master/komga/docs/openapi.json#L2935
+        """
+        return self.update_metadata(book_id, metadata, "books")
+    
+    def update_thumbnail(self, id, thumbnail, thumbnail_type):
+        """
+        Updates the thumbnail of a specified comic.
         """
         try:
-            # make a POST request to the URL to update the thumbnail for a given series
             response = self.r.post(
-                f"{self.base_url}/series/{series_id}/thumbnails?selected=true",
+                f"{self.base_url}/{thumbnail_type}/{id}/thumbnails?selected=true",
                 files=thumbnail,
             )
             response.raise_for_status()
@@ -277,39 +290,18 @@ class KomgaApi:
                 logger.error(f"出现错误: {e}")
         # return True if the status code indicates success, False otherwise
         return response.status_code == 200
-
-    def update_book_metadata(self, book_id, metadata):
+    
+    def update_series_thumbnail(self, series_id, thumbnail):
         """
-        Updates the metadata of a specified comic book.
-
-        https://github.com/gotson/komga/blob/master/komga/docs/openapi.json#L2935
+        Updates the thumbnail of a specified comic series.
         """
-        try:
-            # make a PATCH request to the URL to update the metadata for a given book
-            response = self.r.patch(
-                f"{self.base_url}/books/{book_id}/metadata", json=metadata
-            )
-            response.raise_for_status()
-        except requests.exceptions.RequestException as e:
-            logger.error(f"出现错误: {e}")
-        # return True if the status code indicates success, False otherwise
-        return response.status_code == 204
+        return self.update_thumbnail(series_id, thumbnail, "series")
 
     def update_book_thumbnail(self, book_id, thumbnail):
         """
         Updates the thumbnail of a specified comic book.
         """
-        try:
-            # make a POST request to the URL to update the thumbnail for a given series
-            response = self.r.post(
-                f"{self.base_url}/books/{book_id}/thumbnails?selected=true",
-                files=thumbnail,
-            )
-            response.raise_for_status()
-        except requests.exceptions.RequestException as e:
-            logger.error(f"出现错误: {e}")
-        # return True if the status code indicates success, False otherwise
-        return response.status_code == 200
+        return self.update_thumbnail(book_id, thumbnail, "books")
 
     def add_collection(self, name, ordered, seriesIds):
         """

--- a/api/komga_api.py
+++ b/api/komga_api.py
@@ -5,7 +5,8 @@
 
 
 import requests
-from tools.log import logger
+import logging
+logger = logging.getLogger(__name__)
 from requests.adapters import HTTPAdapter
 
 

--- a/api/komga_api.py
+++ b/api/komga_api.py
@@ -64,7 +64,7 @@ class KomgaApi:
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             logger.error(f"出现错误: {e}")
-            return []
+            return {}
         return response.json()
 
     def get_specific_series(self, series_id):
@@ -79,7 +79,7 @@ class KomgaApi:
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             logger.error(f"出现错误: {e}")
-            return []
+            return {}
         # 将response作为JSON对象返回
         return response.json()
 
@@ -108,7 +108,7 @@ class KomgaApi:
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             logger.error(f"出现错误: {e}")
-            return []
+            return {}
         # 将response作为JSON对象返回
         return response.json()
 
@@ -171,7 +171,7 @@ class KomgaApi:
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             logger.error(f"出现错误: {e}")
-            return []
+            return {}
         # return the response as a JSON object
         return response.json()
 
@@ -210,7 +210,7 @@ class KomgaApi:
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             logger.error(f"出现错误: {e}")
-            return []
+            return {}
         # return the response as a JSON object
         return response.json()
 

--- a/api/komga_sse_api.py
+++ b/api/komga_sse_api.py
@@ -17,7 +17,8 @@ from requests.adapters import HTTPAdapter
 from threading import Thread, Lock
 from concurrent.futures import ThreadPoolExecutor
 from functools import lru_cache
-from tools.log import logger
+import logging
+logger = logging.getLogger(__name__)
 from config.config import KOMGA_BASE_URL, KOMGA_EMAIL, KOMGA_EMAIL_PASSWORD, KOMGA_LIBRARY_LIST
 
 # 可配置的订阅事件类型

--- a/api/komga_sse_api.py
+++ b/api/komga_sse_api.py
@@ -125,9 +125,8 @@ class KomgaSseClient:
                     timeout=self.timeout
                 )
             # 防止取不到response.status_code
-            except requests.exceptions.ConnectionError as e:
-                logger.error(
-                    f"Komga SSE 连接错误, HTTP {response.status_code}: {response.reason}")
+            except requests.exceptions.ConnectionError:
+                logger.error("Komga SSE 连接错误: 无法连接至服务器")
                 return
             except Exception as e:
                 logger.error(f"Komga SSE 连接错误: {e}")
@@ -247,7 +246,7 @@ class KomgaSseClient:
                     continue
         except requests.exceptions.RequestException as re:
             # 处理网络层异常（连接超时、断开等）
-            self.on_error(f"读取 SSE 流数据时网络连接中断, {e}")
+            self.on_error(f"读取 SSE 流数据时网络连接中断, {re}")
 
         except Exception as e:
             # 处理其他未知异常
@@ -263,6 +262,8 @@ class KomgaSseClient:
             # 数据有效性验证
             if isinstance(data, str):
                 json_data = json.loads(data)
+            else:
+                json_data = data
             # 确保 json_data 是字典
             if not isinstance(json_data, dict):
                 raise Exception(f"事件数据不是有效的JSON格式")
@@ -396,23 +397,23 @@ class KomgaSseApi:
     def _get_series_lock(self, series_id):
         return threading.Lock()
 
-    def on_message(self, data):
-        logger.debug(f"收到非订阅 SSE 消息: {data}")
+    def on_message(self, msg):
+        logger.debug(f"收到非订阅 SSE 消息: {msg}")
 
-    def on_error(self, e: Exception):
+    def on_error(self, err: Exception):
         """错误事件回调函数"""
         # 错误处理行为
-        logger.error(f"遇到 SSE 错误: {e} ", exc_info=True)
+        logger.error(f"遇到 SSE 错误: {err} ", exc_info=True)
         # 错误自动重连
-        if "connection" in str(e).lower():
+        if "connection" in str(err).lower():
             self._restart_sse_client()
 
-    def on_event(self, event_type, event_data):
+    def on_event(self, event_type, data):
         """订阅事件回调函数"""
         # 仅通知在 RefreshEventType 类型的事件
         if event_type in RefreshEventType:
-            logger.debug(f"捕获订阅事件 [{event_type}]:{event_data}")
-            library_id = event_data.get("libraryId")
+            logger.debug(f"捕获订阅事件 [{event_type}]:{data}")
+            library_id = data.get("libraryId")
             # 判断 KOMGA_LIBRARY_LIST 是否为空
             if not KOMGA_LIBRARY_LIST:
                 pass
@@ -422,7 +423,7 @@ class KomgaSseApi:
                     f"libraryId: {library_id} 不在 KOMGA_LIBRARY_LIST 中，跳过")
                 return
             # 要不要在这里用多线程来执行 _notify_callbacks 呢?
-            arg = {"event_type": event_type, "event_data": event_data}
+            arg = {"event_type": event_type, "event_data": data}
             self._notify_callbacks(arg)
         else:
-            logger.debug(f"捕获无关事件 [{event_type}]:{event_data}")
+            logger.debug(f"捕获无关事件 [{event_type}]:{data}")

--- a/bangumi_archive/archive_autoupdater.py
+++ b/bangumi_archive/archive_autoupdater.py
@@ -3,7 +3,8 @@ import zipfile
 import requests
 import json
 from config.config import ARCHIVE_FILES_DIR
-from tools.log import logger
+import logging
+logger = logging.getLogger(__name__)
 from bangumi_archive.local_archive_indexed_reader import IndexedDataReader
 from tools.cache_time import TimeCacheManager
 

--- a/bangumi_archive/local_archive_indexed_reader.py
+++ b/bangumi_archive/local_archive_indexed_reader.py
@@ -8,7 +8,8 @@ from threading import Lock
 from datetime import datetime, timezone
 from threading import Lock
 from typing import Dict, List, Union
-from tools.log import logger
+import logging
+logger = logging.getLogger(__name__)
 
 
 class IndexedDataReader:

--- a/bangumi_archive/local_archive_searcher.py
+++ b/bangumi_archive/local_archive_searcher.py
@@ -1,6 +1,7 @@
 import re
 import json
-from tools.log import logger
+import logging
+logger = logging.getLogger(__name__)
 from bangumi_archive.local_archive_indexed_reader import IndexedDataReader
 
 

--- a/bangumi_archive/periodic_archive_checker.py
+++ b/bangumi_archive/periodic_archive_checker.py
@@ -1,6 +1,7 @@
 import threading
 import time
-from tools.log import logger
+import logging
+logger = logging.getLogger(__name__)
 from config.config import USE_BANGUMI_ARCHIVE, ARCHIVE_UPDATE_INTERVAL
 from bangumi_archive.archive_autoupdater import check_archive
 

--- a/core/process_metadata.py
+++ b/core/process_metadata.py
@@ -337,22 +337,23 @@ def set_komga_book_metadata(subject_id, number, name, bgm):
     # authors
     authors = []
     for info in bangumi_metadata["infobox"]:
-        if info["key"] == "作者":
-            """
-            基础格式：{'name':'值','role':'角色类型'}
-            角色类型有：
-                writer:作者
-                inker:画图者
-                translator:翻译者
-                editor:主编
-                cover:封面
-                letterer:嵌字者
-                colorist:上色者
-                penciller:铅稿
-                自定义的角色类型值
-            """
-            author = {"name": info["value"], "role": "writer"}
-            authors.append(author)
+        """
+        基础格式：{'name':'值','role':'角色类型'}
+        角色类型有：
+            writer:作者
+            inker:画图者
+            translator:翻译者
+            editor:主编
+            cover:封面
+            letterer:嵌字者
+            colorist:上色者
+            penciller:铅稿
+            自定义的角色类型值
+        """
+        if info["key"] in ["作者", "原作"] and info.get("value"):
+            authors.append({"name": info["value"].replace(" ", ""), "role": "writer"})
+        if info["key"] in ["作画"] and info.get("value"):
+            authors.append({"name": info["value"].replace(" ", ""), "role": "penciller"})
     komga_book_metadata.authors = authors
     # releaseDate
     komga_book_metadata.releaseDate = bangumi_metadata["date"]

--- a/core/refresh_metadata.py
+++ b/core/refresh_metadata.py
@@ -169,7 +169,8 @@ def refresh_metadata(series_list=None):
             # 确保没有上传过海报，避免重复上传
             if (
                 USE_BANGUMI_THUMBNAIL
-                and len(komga.get_series_thumbnails(series_id)) == 0
+                and len(komga.get_series_thumbnails(series_id)) == 0 
+                and not series.get("oneshot", False)
             ):
                 # 尝试多尺寸海报上传
                 for thumbnail_size in ['large', 'common', 'medium']:
@@ -392,7 +393,7 @@ def refresh_partial_metadata():
     return
 
 
-def update_book_metadata(book_id, related_subject, book_name, number):
+def update_book_metadata(book_id, related_subject, book_name, number, is_oneshot=False):
     # Get the metadata for the book from bangumi
     book_metadata = process_metadata.set_komga_book_metadata(
         related_subject["id"], number, book_name, bgm
@@ -423,10 +424,9 @@ def update_book_metadata(book_id, related_subject, book_name, number):
 
         # 使用 Bangumi 图片替换原封面
         # 确保没有上传过海报，避免重复上传，排除 komga 生成的封面
-        if (
+        if ((
             USE_BANGUMI_THUMBNAIL_FOR_BOOK
-            and len(komga.get_book_thumbnails(book_id)) == 1
-        ):
+        ) or (is_oneshot and USE_BANGUMI_THUMBNAIL)) and len(komga.get_book_thumbnails(book_id)) == 1:
             # 尝试多尺寸海报上传
             for thumbnail_size in ['large', 'common', 'medium']:
                 # 获取当前尺寸的封面
@@ -485,6 +485,7 @@ def refresh_book_metadata(subject_id, series_id, force_refresh_flag):
     for book in books["content"]:
         book_id = book["id"]
         book_name = book["name"]
+        is_oneshot = book.get("oneshot", False)
 
         # Get the subject id from the Correct Bgm Link (CBL) if it exists
         for link in book["metadata"]["links"]:
@@ -493,7 +494,7 @@ def refresh_book_metadata(subject_id, series_id, force_refresh_flag):
                     link["url"].split("/")[-1])
                 number, _ = get_number(
                     cbl_subject["name"] + cbl_subject["name_cn"])
-                update_book_metadata(book_id, cbl_subject, book_name, number)
+                update_book_metadata(book_id, cbl_subject, book_name, number, is_oneshot)
                 break
 
         # 找到对应的book_record
@@ -543,7 +544,7 @@ def refresh_book_metadata(subject_id, series_id, force_refresh_flag):
                     ep_flag = False
 
                     update_book_metadata(
-                        book_id, related_subjects[i], book_name, number
+                        book_id, related_subjects[i], book_name, number, is_oneshot
                     )
 
                     break

--- a/core/refresh_metadata.py
+++ b/core/refresh_metadata.py
@@ -51,6 +51,7 @@ def refresh_metadata(series_list=None):
 
         # 若存在 Correct Bgm Link (CBL) 则获取其中的 subject_id
         subject_id = None
+        metadata = None
         force_refresh_flag = False
         for link in series["metadata"]["links"]:
             if link["label"].lower() == "cbl":
@@ -338,7 +339,9 @@ def _filter_new_modified_series(library_id=None):
             komga_modified_time = TimeCacheManager.convert_to_datetime(
                 item["lastModified"]
             )
-            if komga_modified_time > local_last_modified:
+            if (komga_modified_time is not None
+                    and local_last_modified is not None
+                    and komga_modified_time > local_last_modified):
                 new_series.append(item)
             else:
                 # 如果没有新更改的系列，停止分页
@@ -364,7 +367,7 @@ def refresh_partial_metadata():
     if KOMGA_LIBRARY_LIST:
         for libray_item in KOMGA_LIBRARY_LIST:
             series_list = _filter_new_modified_series(
-                libray_item["LIBRARY"])["content"]
+                libray_item["LIBRARY"])
             for series in series_list:
                 series["is_novel"] = libray_item["IS_NOVEL_ONLY"]
             recent_modified_series.extend(series_list)

--- a/core/refresh_metadata.py
+++ b/core/refresh_metadata.py
@@ -5,7 +5,8 @@ import core.process_metadata as process_metadata
 from time import strftime, localtime
 from tools.get_number import get_number, NumberType
 from tools.env import *
-from tools.log import logger
+import logging
+logger = logging.getLogger(__name__)
 from tools.notification import send_notification
 from tools.db import init_sqlite3, record_series_status, record_book_status
 from tools.cache_time import TimeCacheManager

--- a/core/refresh_metadata.py
+++ b/core/refresh_metadata.py
@@ -47,6 +47,7 @@ def refresh_metadata(series_list=None):
         series_id = series["id"]
         series_name = series["name"]
         is_novel_series = series["is_novel"]
+        is_oneshot = series.get("oneshot", False)
 
         # 若存在 Correct Bgm Link (CBL) 则获取其中的 subject_id
         subject_id = None
@@ -138,7 +139,6 @@ def refresh_metadata(series_list=None):
             continue
 
         series_data = {
-            "status": komga_metadata.status,
             "summary": komga_metadata.summary,
             "publisher": komga_metadata.publisher,
             "genres": komga_metadata.genres,
@@ -147,14 +147,15 @@ def refresh_metadata(series_list=None):
             "alternateTitles": komga_metadata.alternateTitles,
             "ageRating": komga_metadata.ageRating,
             "links": komga_metadata.links,
-            "totalBookCount": komga_metadata.totalBookCount,
             "language": komga_metadata.language,
             "titleSort": komga_metadata.titleSort,
         }
+        if not is_oneshot:
+            series_data["status"] = komga_metadata.status
+            series_data["totalBookCount"] = komga_metadata.totalBookCount
 
         # Update the metadata for the series on komga
-        is_success = komga.update_series_metadata(series_id, series_data)
-        if is_success:
+        if komga.update_series_metadata(series_id, series_data):
             success_count, success_comic = record_series_status(
                 conn,
                 series_id,
@@ -170,7 +171,7 @@ def refresh_metadata(series_list=None):
             if (
                 USE_BANGUMI_THUMBNAIL
                 and len(komga.get_series_thumbnails(series_id)) == 0 
-                and not series.get("oneshot", False)
+                and not is_oneshot
             ):
                 # 尝试多尺寸海报上传
                 for thumbnail_size in ['large', 'common', 'medium']:
@@ -179,10 +180,7 @@ def refresh_metadata(series_list=None):
                         metadata, image_size=thumbnail_size)
 
                     # 尝试更新封面
-                    replace_thumbnail_result = komga.update_series_thumbnail(
-                        series_id, thumbnail)
-
-                    if replace_thumbnail_result:
+                    if komga.update_series_thumbnail(series_id, thumbnail):
                         logger.debug("成功替换系列: %s 的海报", series_name)
                         # 成功则跳出海报更新循环
                         break
@@ -212,8 +210,6 @@ def refresh_metadata(series_list=None):
 
     # 将匹配失败的系列加入收藏 FAILED_COLLECTION
     if CREATE_FAILED_COLLECTION:
-        collection_name = "FAILED_COLLECTION"
-
         # TODO: 匹配错误的系列其update_success也是1, 需要找到一种方法将之筛选出来
 
         # 将db中update_success为0的series_ids筛选出来
@@ -228,6 +224,7 @@ def refresh_metadata(series_list=None):
         ]
         # 用 all_failed_series_ids 创建 FAILED_COLLECTION
         if all_failed_series_ids:
+            collection_name = "FAILED_COLLECTION"
             if komga.replace_collection(collection_name, False, all_failed_series_ids):
                 logger.info("成功替换收藏: %s", collection_name)
             else:
@@ -417,8 +414,7 @@ def update_book_metadata(book_id, related_subject, book_name, number, is_oneshot
     }
 
     # Update the metadata for the series on komga
-    is_success = komga.update_book_metadata(book_id, book_data)
-    if is_success:
+    if komga.update_book_metadata(book_id, book_data):
         record_book_status(
             conn, book_id, related_subject["id"], 1, book_name, "")
 
@@ -434,10 +430,7 @@ def update_book_metadata(book_id, related_subject, book_name, number, is_oneshot
                     related_subject, image_size=thumbnail_size)
 
                 # 尝试更新封面
-                replace_thumbnail_result = komga.update_book_thumbnail(
-                    book_id, thumbnail)
-
-                if replace_thumbnail_result:
+                if komga.update_book_thumbnail(book_id, thumbnail):
                     logger.debug("替换书籍: %s 的海报 ", book_name)
                     # 成功则跳出海报更新循环
                     break
@@ -460,7 +453,7 @@ def refresh_book_metadata(subject_id, series_id, force_refresh_flag):
     """
     刷新书元数据
     """
-    if subject_id == None:
+    if subject_id is None:
         return
 
     related_subjects = None

--- a/main.py
+++ b/main.py
@@ -1,7 +1,9 @@
+from tools.log import init_logger
 from services.service_runner import run_service
 
 
 def main():
+    init_logger()
     run_service()
 
 

--- a/scripts/sort_title_by_letter.py
+++ b/scripts/sort_title_by_letter.py
@@ -2,7 +2,8 @@ import sys, os
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../")))
 from tools.env import *
-from tools.log import logger
+import logging
+logger = logging.getLogger(__name__)
 from pypinyin import slug, Style
 
 env = InitEnv()

--- a/scripts/update_read_progress.py
+++ b/scripts/update_read_progress.py
@@ -1,6 +1,7 @@
 from config.config import *
 from tools.env import *
-from tools.log import logger
+import logging
+logger = logging.getLogger(__name__)
 from warnings import deprecated
 
 

--- a/services/polling_service.py
+++ b/services/polling_service.py
@@ -2,7 +2,8 @@ import threading
 import time
 import os
 import sqlite3
-from tools.log import logger
+import logging
+logger = logging.getLogger(__name__)
 from config.config import (
     BANGUMI_KOMGA_SERVICE_POLL_INTERVAL,
     BANGUMI_KOMGA_SERVICE_POLL_REFRESH_ALL_METADATA_INTERVAL,

--- a/services/service_runner.py
+++ b/services/service_runner.py
@@ -1,6 +1,7 @@
 from services.polling_service import poll_service
 from services.sse_service import sse_service
-from tools.log import logger
+import logging
+logger = logging.getLogger(__name__)
 import threading
 from config.config import BANGUMI_KOMGA_SERVICE_TYPE
 from core.refresh_metadata import refresh_metadata

--- a/services/sse_service.py
+++ b/services/sse_service.py
@@ -1,5 +1,6 @@
 import threading
-from tools.log import logger
+import logging
+logger = logging.getLogger(__name__)
 
 from config.config import KOMGA_LIBRARY_LIST
 from core.refresh_metadata import refresh_metadata, get_series_metadata

--- a/tests/test_tools_cache_time.py
+++ b/tests/test_tools_cache_time.py
@@ -3,7 +3,8 @@ import json
 from datetime import datetime
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from tools.log import logger
+import logging
+logger = logging.getLogger(__name__)
 from tools.cache_time import TimeCacheManager
 
 

--- a/tests/test_tools_notification.py
+++ b/tests/test_tools_notification.py
@@ -1,7 +1,8 @@
 import unittest
 from unittest.mock import patch, Mock
 import requests
-from tools.log import logger
+import logging
+logger = logging.getLogger(__name__)
 from tools.notification import send_notification
 
 

--- a/tests/test_tools_resort_search_results_list.py
+++ b/tests/test_tools_resort_search_results_list.py
@@ -2,7 +2,8 @@ import unittest
 from unittest.mock import MagicMock, patch
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
-from tools.log import logger
+import logging
+logger = logging.getLogger(__name__)
 from tools.resort_search_results_list import resort_search_list, compute_name_score_by_fuzzy
 
 

--- a/tools/cache_time.py
+++ b/tools/cache_time.py
@@ -1,7 +1,8 @@
 import json
 from datetime import datetime, timedelta
 from typing import Optional
-from tools.log import logger
+import logging
+logger = logging.getLogger(__name__)
 
 
 class TimeCacheManager:

--- a/tools/cache_time.py
+++ b/tools/cache_time.py
@@ -10,6 +10,7 @@ class TimeCacheManager:
     时间缓存管理类，处理更新时间记录的读写和转换
     """
 
+    @staticmethod
     def read_time(file_path) -> str:
         """
         读取缓存中的更新时间字符串
@@ -24,6 +25,7 @@ class TimeCacheManager:
             logger.warning(f"缓存文件 {file_path} 解析失败: {str(e)}")
             return "1970-01-01T00:00:00Z"
 
+    @staticmethod
     def save_time(file_path, last_updated: str) -> None:
         """
         保存最新更新时间到缓存
@@ -31,17 +33,19 @@ class TimeCacheManager:
         with open(file_path, "w") as f:
             json.dump({"last_updated": last_updated}, f)
 
-    def convert_to_timedelta(input_seconds: int) -> Optional[datetime]:
+    @staticmethod
+    def convert_to_timedelta(seconds: int) -> Optional[timedelta]:
         """
-        将分钟数转换为 datetime 对象
+        将秒数转换为 timedelta 对象
         """
         try:
-            result = timedelta(minutes=input_seconds)
+            result = timedelta(seconds=seconds)
         except Exception as e:
-            logger.warning(f"时间值 {input_seconds} 转换失败: {str(e)}")
+            logger.warning(f"时间值 {seconds} 转换失败: {str(e)}")
             return None
         return result
 
+    @staticmethod
     def convert_to_datetime(time_str: str) -> Optional[datetime]:
         """
         将 ISO 格式字符串转换为 datetime 对象

--- a/tools/db.py
+++ b/tools/db.py
@@ -1,6 +1,7 @@
 import sqlite3
 from time import strftime, localtime
-from tools.log import logger
+import logging
+logger = logging.getLogger(__name__)
 
 
 def upsert_series_record(

--- a/tools/env.py
+++ b/tools/env.py
@@ -3,7 +3,8 @@ import api.komga_api as komga_api
 from config.config import *
 import os
 import sqlite3
-from tools.log import logger
+import logging
+logger = logging.getLogger(__name__)
 from config.configuration_generator import start_config_generate
 
 

--- a/tools/log.py
+++ b/tools/log.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import logging
 from logging.handlers import RotatingFileHandler
@@ -5,29 +6,39 @@ from logging.handlers import RotatingFileHandler
 
 def is_in_debug():
     """检测是否在调试模式下运行"""
-    result = sys.gettrace()
-    logger.debug(f"调试器检测结果: {result}")
-    return bool(result)
+    return bool(sys.gettrace())
 
+def init_logger(debug_mode=None, log_dir='logs', log_file_name='refreshMetadata.log'):
+    """初始化日志记录器"""
+    if debug_mode is None:
+        debug_mode = is_in_debug()
+    logger = logging.getLogger()
+    if logger.hasHandlers():
+        return logger
+    logger.setLevel(logging.DEBUG)
 
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
-formatter = logging.Formatter(
-    "%(asctime)s - %(name)s - %(levelname)s - %(filename)-8s : %(lineno)s - %(message)s"
-)
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(filename)-8s : %(lineno)s - %(message)s"
+    )
 
-fh = RotatingFileHandler(
-    filename="logs/refreshMetadata.log",
-    maxBytes=10000000,
-    backupCount=9,
-    encoding="utf-8",
-)
-fh.setFormatter(formatter)
-fh.setLevel(logging.INFO)
-logger.addHandler(fh)
+    # 创建日志目录
+    os.makedirs(log_dir, exist_ok=True)
+    log_file_path = os.path.join(log_dir, log_file_name)
 
-sh = logging.StreamHandler(sys.stdout)
-sh.setFormatter(formatter)
-# 感知调试器, 切换日志等级
-sh.setLevel(logging.DEBUG if is_in_debug() else logging.INFO)
-logger.addHandler(sh)
+    fh = RotatingFileHandler(
+        filename=log_file_path,
+        maxBytes=10000000,
+        backupCount=9,
+        encoding="utf-8",
+    )
+    fh.setFormatter(formatter)
+    fh.setLevel(logging.INFO)
+    logger.addHandler(fh)
+
+    sh = logging.StreamHandler(sys.stdout)
+    sh.setFormatter(formatter)
+    # 感知调试器, 切换日志等级
+    sh.setLevel(logging.DEBUG if debug_mode else logging.INFO)
+    logger.addHandler(sh)
+
+    return logger

--- a/tools/notification.py
+++ b/tools/notification.py
@@ -1,7 +1,8 @@
 import json
 import requests
 from config.config import *
-from tools.log import logger
+import logging
+logger = logging.getLogger(__name__)
 
 
 def send_notification(title, message):

--- a/tools/slide_window_rate_limiter.py
+++ b/tools/slide_window_rate_limiter.py
@@ -1,7 +1,8 @@
 import time
 from collections import deque
 from functools import wraps
-from tools.log import logger
+import logging
+logger = logging.getLogger(__name__)
 
 
 class SlideWindowCounter:


### PR DESCRIPTION
- Pylance 推断烦死了, 所以试着改掉来消除警告

## Summary by Sourcery

改进元数据刷新和日志记录行为，添加显式类型标注，并在 Komga 和 Bangumi 集成中调整错误处理逻辑，包括对 oneshot 系列/书籍的支持。

Bug 修复：
- 当请求失败时，在 Komga 和 Bangumi 的若干 API 方法中返回 `dict/False` 而不是 `list/None`，以避免返回类型不一致。
- 在筛选最近修改的系列时，对 `None` 值进行保护性处理后再进行 datetime 比较，以防止运行时错误。
- 修复 SSE 错误处理，记录正确的异常，并处理非 JSON 的 SSE 负载。
- 避免处理本地 Bangumi 归档条目中缺失的相关条目（related subject）元数据，以防止键错误（key error）。

增强：
- 在 Komga API 中为系列和书籍引入共享的元数据和缩略图更新辅助函数。
- 在刷新系列和书籍元数据以及决定是否更新缩略图时，添加对 oneshot 的识别逻辑。
- 优化 Bangumi 书籍元数据中的作者角色映射，根据 infobox 中的键来区分编剧和作画。
- 将 `TimeCacheManager` 方法改为静态方法，并调整时间转换语义为基于秒的 `timedelta`。
- 重构日志记录，使用 `init_logger` 辅助函数和模块级 logger，而不是导入全局 logger。
- 调整离线 Bangumi 数据源方法，对不支持的操作抛出 `NotImplementedError`，并通过工厂封装层向外传播结果。

文档：
- 更新 README，记录 oneshot 支持情况，并澄清 Docker Compose 和原生部署两种方式的部署选项。

测试：
- 让现有测试与日志和 `TimeCacheManager` 的变更保持一致，而不改变其测试意图。

杂项：
- 在主入口中接入日志初始化，并清理元数据刷新流程中的一些控制流与变量使用上的小问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve metadata refresh and logging behavior, add explicit typing, and adjust error handling across Komga and Bangumi integrations, including support for oneshot series/books.

Bug Fixes:
- Return dict/False instead of list/None from several API methods on Komga and Bangumi when requests fail, avoiding inconsistent types.
- Guard datetime comparisons against None values when filtering recently modified series to prevent runtime errors.
- Fix SSE error handling by logging correct exceptions and handling non-JSON SSE payloads.
- Avoid processing missing related subject metadata from local Bangumi archive entries to prevent key errors.

Enhancements:
- Introduce shared helpers for updating metadata and thumbnails in Komga APIs for both series and books.
- Add oneshot-aware logic when refreshing series and book metadata and deciding whether to update thumbnails.
- Refine author role mapping for Bangumi book metadata, distinguishing writers and artists based on infobox keys.
- Make TimeCacheManager methods static and adjust time conversion semantics to use seconds-based timedeltas.
- Refactor logging to use an init_logger helper and module-level loggers instead of importing a global logger.
- Adjust offline Bangumi data source methods to raise NotImplementedError for unsupported operations and propagate results through the factory wrapper.

Documentation:
- Update README to document oneshot support and clarify deployment options for Docker compose and native setups.

Tests:
- Keep existing tests aligned with logging and TimeCacheManager changes without altering their intent.

Chores:
- Wire logger initialization in main entrypoint and clean up minor control-flow and variable usage in metadata refresh routines.

</details>