### PR TITLE
fix(api & core): 修复返回类型与异常处理逻辑 & 补充类型注解

### DIFF
--- a/api/bangumi_api.py
+++ b/api/bangumi_api.py
@@ -19,8 +19,8 @@ from tools.resort_search_results_list import resort_search_list
 from tools.slide_window_rate_limiter import slide_window_rate_limiter
 from zhconv import convert
 from abc import ABC, abstractmethod
+from typing import Any
 
-# TODO： 在DataSource中添加一个本地缓存目录，将从 API 获取的封面图片保存为文件（如 cache/thumbnails/{subject_id}_{image_size}.jpg），下次直接读取本地文件，避免重复请求
 
 
 class DataSource(ABC):
@@ -29,24 +29,27 @@ class DataSource(ABC):
     """
 
     @abstractmethod
-    def search_subjects(self, query, threshold=80, is_novel=False):
-        pass
+    def search_subjects(self, query: str, threshold: int = 80,
+                        is_novel: bool = False) -> list:
+        ...
 
     @abstractmethod
-    def get_subject_metadata(self, subject_id):
-        pass
+    def get_subject_metadata(self, subject_id: Any) -> dict:
+        ...
 
     @abstractmethod
-    def get_related_subjects(self, subject_id):
-        pass
+    def get_related_subjects(self, subject_id: Any) -> list:
+        ...
 
     @abstractmethod
-    def update_reading_progress(self, subject_id, progress):
-        pass
+    def update_reading_progress(self, subject_id: Any,
+                                progress: Any) -> bool:
+        ...
 
     @abstractmethod
-    def get_subject_thumbnail(self, subject_metadata, image_size):
-        pass
+    def get_subject_thumbnail(self, subject_metadata: dict,
+                              image_size: str) -> dict:
+        ...
 
 
 class BangumiApiDataSource(DataSource):
@@ -123,7 +126,7 @@ class BangumiApiDataSource(DataSource):
             logger.error(
                 f"请检查 {subject_id} 是否填写正确；或属于 NSFW，但并未配置 BANGUMI_ACCESS_TOKEN"
             )
-            return []
+            return {}
         return response.json()
 
     @slide_window_rate_limiter()
@@ -152,6 +155,7 @@ class BangumiApiDataSource(DataSource):
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             logger.error(f"出现错误: {e}")
+            return False
         return response.status_code == 204
 
     @slide_window_rate_limiter()
@@ -172,7 +176,7 @@ class BangumiApiDataSource(DataSource):
             thumbnail = self.r.get(image).content
         except Exception as e:
             logger.error(f"出现错误: {e}")
-            return []
+            return {}
         files = {"file": (subject_metadata["name"], thumbnail)}
         return files
 
@@ -275,6 +279,8 @@ class BangumiArchiveDataSource(DataSource):
                     metadata = self._get_metadata_from_archive(
                         item.get("related_subject_id", 0)
                     )
+                    if not metadata:
+                        continue
                     result = {
                         "name": metadata.get("name"),
                         "name_cn": metadata.get("name_cn"),
@@ -294,15 +300,13 @@ class BangumiArchiveDataSource(DataSource):
         """
         离线数据源更新阅读进度
         """
-        NotImplementedError("离线数据源不支持更新阅读进度")
-        return False
+        raise NotImplementedError("离线数据源不支持更新阅读进度")
 
     def get_subject_thumbnail(self, subject_metadata, image_size):
         """
         离线数据源获取封面
         """
-        NotImplementedError("离线数据源不支持获取封面")
-        return {}
+        raise NotImplementedError("离线数据源不支持获取封面")
 
 
 class BangumiDataSourceFactory:
@@ -356,7 +360,7 @@ class FallbackDataSource(DataSource):
         return self._fallback_call("get_related_subjects", subject_id)
 
     def update_reading_progress(self, subject_id, progress):
-        self._fallback_call("update_reading_progress", subject_id, progress)
+        return self._fallback_call("update_reading_progress", subject_id, progress)
 
     def get_subject_thumbnail(self, subject_metadata, image_size):
         return self._fallback_call(

--- a/api/bangumi_api.py
+++ b/api/bangumi_api.py
@@ -300,13 +300,15 @@ class BangumiArchiveDataSource(DataSource):
         """
         离线数据源更新阅读进度
         """
-        raise NotImplementedError("离线数据源不支持更新阅读进度")
+        logger.warning("离线数据源不支持更新阅读进度")
+        return False
 
     def get_subject_thumbnail(self, subject_metadata, image_size):
         """
         离线数据源获取封面
         """
-        raise NotImplementedError("离线数据源不支持获取封面")
+        logger.warning("离线数据源不支持获取封面")
+        return {}
 
 
 class BangumiDataSourceFactory:

--- a/api/komga_api.py
+++ b/api/komga_api.py
@@ -64,7 +64,7 @@ class KomgaApi:
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             logger.error(f"出现错误: {e}")
-            return []
+            return {}
         return response.json()
 
     def get_specific_series(self, series_id):
@@ -79,7 +79,7 @@ class KomgaApi:
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             logger.error(f"出现错误: {e}")
-            return []
+            return {}
         # 将response作为JSON对象返回
         return response.json()
 
@@ -108,7 +108,7 @@ class KomgaApi:
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             logger.error(f"出现错误: {e}")
-            return []
+            return {}
         # 将response作为JSON对象返回
         return response.json()
 
@@ -171,7 +171,7 @@ class KomgaApi:
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             logger.error(f"出现错误: {e}")
-            return []
+            return {}
         # return the response as a JSON object
         return response.json()
 
@@ -210,7 +210,7 @@ class KomgaApi:
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             logger.error(f"出现错误: {e}")
-            return []
+            return {}
         # return the response as a JSON object
         return response.json()
 

--- a/api/komga_sse_api.py
+++ b/api/komga_sse_api.py
@@ -262,6 +262,8 @@ class KomgaSseClient:
             # 数据有效性验证
             if isinstance(data, str):
                 json_data = json.loads(data)
+            elif isinstance(data, bytes):
+                json_data = json.loads(data.decode("utf-8"))
             else:
                 json_data = data
             # 确保 json_data 是字典
@@ -400,7 +402,7 @@ class KomgaSseApi:
     def on_message(self, msg):
         logger.debug(f"收到非订阅 SSE 消息: {msg}")
 
-    def on_error(self, err: Exception):
+    def on_error(self, err):  # str | Exception
         """错误事件回调函数"""
         # 错误处理行为
         logger.error(f"遇到 SSE 错误: {err} ", exc_info=True)

--- a/api/komga_sse_api.py
+++ b/api/komga_sse_api.py
@@ -125,9 +125,8 @@ class KomgaSseClient:
                     timeout=self.timeout
                 )
             # 防止取不到response.status_code
-            except requests.exceptions.ConnectionError as e:
-                logger.error(
-                    f"Komga SSE 连接错误, HTTP {response.status_code}: {response.reason}")
+            except requests.exceptions.ConnectionError:
+                logger.error("Komga SSE 连接错误: 无法连接至服务器")
                 return
             except Exception as e:
                 logger.error(f"Komga SSE 连接错误: {e}")
@@ -247,7 +246,7 @@ class KomgaSseClient:
                     continue
         except requests.exceptions.RequestException as re:
             # 处理网络层异常（连接超时、断开等）
-            self.on_error(f"读取 SSE 流数据时网络连接中断, {e}")
+            self.on_error(f"读取 SSE 流数据时网络连接中断, {re}")
 
         except Exception as e:
             # 处理其他未知异常
@@ -263,6 +262,8 @@ class KomgaSseClient:
             # 数据有效性验证
             if isinstance(data, str):
                 json_data = json.loads(data)
+            else:
+                json_data = data
             # 确保 json_data 是字典
             if not isinstance(json_data, dict):
                 raise Exception(f"事件数据不是有效的JSON格式")
@@ -396,23 +397,23 @@ class KomgaSseApi:
     def _get_series_lock(self, series_id):
         return threading.Lock()
 
-    def on_message(self, data):
-        logger.debug(f"收到非订阅 SSE 消息: {data}")
+    def on_message(self, msg):
+        logger.debug(f"收到非订阅 SSE 消息: {msg}")
 
-    def on_error(self, e: Exception):
+    def on_error(self, err: Exception):
         """错误事件回调函数"""
         # 错误处理行为
-        logger.error(f"遇到 SSE 错误: {e} ", exc_info=True)
+        logger.error(f"遇到 SSE 错误: {err} ", exc_info=True)
         # 错误自动重连
-        if "connection" in str(e).lower():
+        if "connection" in str(err).lower():
             self._restart_sse_client()
 
-    def on_event(self, event_type, event_data):
+    def on_event(self, event_type, data):
         """订阅事件回调函数"""
         # 仅通知在 RefreshEventType 类型的事件
         if event_type in RefreshEventType:
-            logger.debug(f"捕获订阅事件 [{event_type}]:{event_data}")
-            library_id = event_data.get("libraryId")
+            logger.debug(f"捕获订阅事件 [{event_type}]:{data}")
+            library_id = data.get("libraryId")
             # 判断 KOMGA_LIBRARY_LIST 是否为空
             if not KOMGA_LIBRARY_LIST:
                 pass
@@ -422,7 +423,7 @@ class KomgaSseApi:
                     f"libraryId: {library_id} 不在 KOMGA_LIBRARY_LIST 中，跳过")
                 return
             # 要不要在这里用多线程来执行 _notify_callbacks 呢?
-            arg = {"event_type": event_type, "event_data": event_data}
+            arg = {"event_type": event_type, "event_data": data}
             self._notify_callbacks(arg)
         else:
-            logger.debug(f"捕获无关事件 [{event_type}]:{event_data}")
+            logger.debug(f"捕获无关事件 [{event_type}]:{data}")

--- a/core/refresh_metadata.py
+++ b/core/refresh_metadata.py
@@ -51,6 +51,7 @@ def refresh_metadata(series_list=None):
 
         # 若存在 Correct Bgm Link (CBL) 则获取其中的 subject_id
         subject_id = None
+        metadata = None
         force_refresh_flag = False
         for link in series["metadata"]["links"]:
             if link["label"].lower() == "cbl":
@@ -338,7 +339,9 @@ def _filter_new_modified_series(library_id=None):
             komga_modified_time = TimeCacheManager.convert_to_datetime(
                 item["lastModified"]
             )
-            if komga_modified_time > local_last_modified:
+            if (komga_modified_time is not None
+                    and local_last_modified is not None
+                    and komga_modified_time > local_last_modified):
                 new_series.append(item)
             else:
                 # 如果没有新更改的系列，停止分页
@@ -364,7 +367,7 @@ def refresh_partial_metadata():
     if KOMGA_LIBRARY_LIST:
         for libray_item in KOMGA_LIBRARY_LIST:
             series_list = _filter_new_modified_series(
-                libray_item["LIBRARY"])["content"]
+                libray_item["LIBRARY"])
             for series in series_list:
                 series["is_novel"] = libray_item["IS_NOVEL_ONLY"]
             recent_modified_series.extend(series_list)

--- a/tools/cache_time.py
+++ b/tools/cache_time.py
@@ -10,6 +10,7 @@ class TimeCacheManager:
     时间缓存管理类，处理更新时间记录的读写和转换
     """
 
+    @staticmethod
     def read_time(file_path) -> str:
         """
         读取缓存中的更新时间字符串
@@ -24,6 +25,7 @@ class TimeCacheManager:
             logger.warning(f"缓存文件 {file_path} 解析失败: {str(e)}")
             return "1970-01-01T00:00:00Z"
 
+    @staticmethod
     def save_time(file_path, last_updated: str) -> None:
         """
         保存最新更新时间到缓存
@@ -31,17 +33,19 @@ class TimeCacheManager:
         with open(file_path, "w") as f:
             json.dump({"last_updated": last_updated}, f)
 
-    def convert_to_timedelta(input_seconds: int) -> Optional[datetime]:
+    @staticmethod
+    def convert_to_timedelta(seconds: int) -> Optional[timedelta]:
         """
-        将分钟数转换为 datetime 对象
+        将秒数转换为 timedelta 对象
         """
         try:
-            result = timedelta(minutes=input_seconds)
+            result = timedelta(seconds=seconds)
         except Exception as e:
-            logger.warning(f"时间值 {input_seconds} 转换失败: {str(e)}")
+            logger.warning(f"时间值 {seconds} 转换失败: {str(e)}")
             return None
         return result
 
+    @staticmethod
     def convert_to_datetime(time_str: str) -> Optional[datetime]:
         """
         将 ISO 格式字符串转换为 datetime 对象


### PR DESCRIPTION
由 https://github.com/chu-shen/BangumiKomga/pull/163 重新提交, 分支点错了

## Summary by Sourcery

使 API 和核心组件在返回类型和错误处理方面保持一致，并改进类型注解和时间缓存工具。

新功能：
- 为 Bangumi 数据源接口及相关方法添加显式类型注解。

错误修复：
- 在 Bangumi 和 Komga API 中，当元数据和缩略图获取失败时返回字典而不是列表，以与成功响应类型保持一致。
- 确保 Bangumi API 的阅读进度更新在请求失败时返回 False，并通过数据源工厂向上传递布尔结果。
- 修复 Komga SSE 错误处理机制，以记录合适的日志消息、传递正确的异常对象，并同时接受字符串和字典类型的事件负载。
- 在获取关联条目的元数据时，对空结果进行保护，避免处理无效条目。
- 当时间戳转换返回 None 时，通过添加空值检查，防止刷新元数据过滤流程失败。
- 修正部分元数据刷新的逻辑，改为使用完整的系列列表结果，而不是从非字典响应中通过索引访问内容。

增强改进：
- 将 TimeCacheManager 方法转换为静态工具方法，并将时间转换语义从“分钟”调整为使用 `timedelta` 的秒数。
- 对不支持的离线数据源操作抛出 NotImplementedError，而不是返回占位值。
- 明确 Komga SSE 回调参数名称，并改进对非订阅事件和订阅事件的日志记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align API and core components with correct return types and error handling while improving type annotations and time-cache utilities.

New Features:
- Add explicit type annotations to Bangumi data source interfaces and related methods.

Bug Fixes:
- Return dictionaries instead of lists on failed metadata and thumbnail fetches in Bangumi and Komga APIs to match successful response types.
- Ensure Bangumi API reading-progress updates return False on request failures and propagate boolean results through the data source factory.
- Fix Komga SSE error handling to log appropriate messages, pass the correct exception objects, and accept both string and dict event payloads.
- Guard metadata retrieval for related subjects against empty results to avoid processing invalid entries.
- Prevent refresh metadata filtering from failing when timestamp conversions return None by adding null checks.
- Correct partial metadata refresh to use the full series list result instead of indexing content from a non-dict response.

Enhancements:
- Convert TimeCacheManager methods to static utilities and adjust time conversion semantics from minutes to timedelta seconds.
- Raise NotImplementedError for unsupported offline data source operations instead of returning placeholder values.
- Clarify Komga SSE callback parameter names and logging for non-subscription and subscription events.

</details>